### PR TITLE
Add the Rebuild Tags command to Sublime's command palette.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,7 @@
+[
+  {
+    "args": {}, 
+    "caption": "CTags: Rebuild Tags",
+    "command": "rebuild_tags"
+  }
+]


### PR DESCRIPTION
I can never remember the hotkey when I actually need to do it, but the command isn't in the palette or in the menus... so I have to go edit a yaml file to figure out what to press :)

This simply adds the Rebuild Tags command to the command palette.
