### PR TITLE
Introduce Global file-suffix based symbol search, add caching for symbol tags

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -45,6 +45,19 @@
     ], 
     "keys": ["alt+shift+s"]
   },
+  {
+    "command": "show_symbols",
+    "args": {"type": "lang"},
+    "context": [
+      {
+        "key": "selector",
+        "match_all": true,
+        "operand": "source -source.css",
+        "operator": "equal"
+      }
+    ], 
+    "keys": ["ctrl+alt+shift+s"]
+  },
   { // override current default
     "command": "transpose",
     "context": [

--- a/ctags.py
+++ b/ctags.py
@@ -226,6 +226,17 @@ class TagFile(object):
 
             self.fh.close()
 
+    def get_by_suffix(self, suffix):
+        with open(self.p, 'r+') as fh:
+            self.fh = mmap.mmap(fh.fileno(), 0)
+
+            for l in fh:
+                if l.split('\t')[self.column].endswith(suffix): yield l
+                else: continue
+
+            self.fh.close()
+
+
     def exact_matches(self, iterator, tag):
         for l in iterator:
             comp = cmp(l.split('\t')[self.column], tag)
@@ -251,6 +262,11 @@ class TagFile(object):
 
     def tag_class(self):
         return type('Tag', (Tag,), dict(root_dir = self.dir))
+
+    def get_tags_dict_by_suffix(self, suffix, **kw):
+        filters = kw.get('filters', [])
+        return parse_tag_lines( self.get_by_suffix(suffix),
+                                tag_class=self.tag_class(), filters=filters)
 
     def get_tags_dict(self, *tags, **kw):
         filters = kw.get('filters', [])


### PR DESCRIPTION
I often want to search all Scala symbols for easy navigation. This adds an option to ShowSymbols to search all files with the same suffix as the currently viewed file.

I also added a in-memory cache for tags loaded from the .ctags file since this can be slow for the above command.
