### PR TITLE
Prevent tags from current view from appearing twice

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -341,6 +341,7 @@ def files_to_search(view, tags_file, multiple=True):
     files = [fn[len(common_prefix)+1:]]
 
     if multiple:
+        files.pop()
         more_files = tagged_project_files(view, tag_dir)
         files.extend(more_files)
 


### PR DESCRIPTION
When using `show_symbols multi`, the tags from the current file appear twice. They appear to be added once, as if multi were not being run, then again as part of the mutli run.
