### PR TITLE
Allow per-project settings override

### DIFF
--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -1,6 +1,17 @@
 {
+    // All options in here can also be specified in your project settings
+    // with a prepended "ctags_" for example if you have
+    //
+    // "settings":
+    // {
+    //     "ctags_command": ""echo \":ctags .tags\" | ghci -v0 /path/to/Main.hs"
+    // }
+    //
+    // in your project settings, this will override the settings specified
+    // in this file and in your user settings.
+
     "debug"           :  false,
-    "ctags_command"   :  "ctags -R -f .tags",
+    "command"   :  "ctags -R -f .tags",
     "filters"         :  {
         "source.python": {"type":"^i$"}
     },

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -31,7 +31,21 @@ from ctags import (FILENAME, parse_tag_lines, PATH_ORDER, SYMBOL, Tag, TagFile)
 
 ################################### SETTINGS ###################################
 
-setting = sublime.load_settings('CTags.sublime-settings').get # (key, None)
+def get_settings():
+    return sublime.load_settings("CTags.sublime-settings")
+
+def get_setting(key, default=None, view=None):
+    try:
+        if view == None:
+            view = sublime.active_window().active_view()
+        s = view.settings()
+        if s.has("ctags_%s" % key):
+            return s.get("ctags_%s" % key)
+    except:
+        pass
+    return get_settings().get(key, default)
+
+setting = get_setting
 
 ################################### CONSTANTS ##################################
 
@@ -660,7 +674,8 @@ class rebuild_tags(sublime_plugin.TextCommand):
         if 0:  # not 1 or sublime.question_box('`ctags -R` in %s ?'% dirname(tag_file)):
             return
 
-        self.build_ctags(setting('ctags_command'), tag_files)
+        command = setting('command', setting('ctags_command'))
+        self.build_ctags(command, tag_files)
 
     @threaded(msg="Already running CTags!")
     def build_ctags(self, cmd, tag_files):


### PR DESCRIPTION
All CTags.sublime-settings options can be overriden by using the ctags_*
prefix from the project settings.

Sublime package settings are a bit wild-west, but this is a convention used by at least one
other module (SublimeClang)

Also abbreviate ctags_command to just command. Previous string is still
checked for backward compatibility.
