### PR TITLE
Fix jump to definition while region is selected

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -531,7 +531,10 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
 
     @ctags_goto_command(jump_directly_if_one=True)
     def run(self, view, args, tags_file):
-        symbol = view.substr(view.word(view.sel()[0]))
+        region = view.sel()[0]
+        if region.begin() == region.end(): #point
+          region = view.word(region)
+        symbol = view.substr(region)
         return JumpToDefinition.run(symbol, view, tags_file)
 
 


### PR DESCRIPTION
I love that I just need to put my cursor anywhere in a word to search for that symbol. But for symbols like `equal?`, the "expand to word" behavior fails because it doesn't consider `?` part of the word. When I highlight all of `equal?`, the plugin fails because it searches for "equal? ", with a trailing space.

This might be a bug with Sublime's view.word() when passed something that isn't a point selection, but I think the correct behavior is to only "expand to word" during point selection. If the user selects a region of text, that should be exactly what is searched for as a symbol.
