### PR TITLE
Add configuration option to disable autocomplete hints

### DIFF
--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -11,6 +11,7 @@
     // in this file and in your user settings.
 
     "debug"           :  false,
+    "autocomplete": false,
     "command"   :  "ctags -R -f .tags",
     "filters"         :  {
         "source.python": {"type":"^i$"}

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -676,17 +676,18 @@ class rebuild_tags(sublime_plugin.TextCommand):
 
 class CTagsAutoComplete(sublime_plugin.EventListener):
     def on_query_completions(self, view, prefix, locations):
-        tags_path = view.window().folders()[0]+"/.tags"
-        results=[]
-        if (not view.window().folders() or not os.path.exists(tags_path)): #check if a project is open and the .tags file exists
+        if setting('autocomplete'):
+            tags_path = view.window().folders()[0]+"/.tags"
+            results=[]
+            if (not view.window().folders() or not os.path.exists(tags_path)): #check if a project is open and the .tags file exists
+                return results
+            f=os.popen("grep -i '^"+prefix+"' '"+tags_path+"' | awk '{ print $1 }'") # grep tags from project directory .tags file
+            for i in f.readlines():
+                results.append([i.strip()])
+            results = [(item,item) for sublist in results for item in sublist] #flatten
+            results = list(set(results)) # make unique
+            results.sort() # sort
             return results
-        f=os.popen("grep -i '^"+prefix+"' '"+tags_path+"' | awk '{ print $1 }'") # grep tags from project directory .tags file
-        for i in f.readlines():
-            results.append([i.strip()])
-        results = [(item,item) for sublist in results for item in sublist] #flatten
-        results = list(set(results)) # make unique
-        results.sort() # sort
-        return results
 
 ##################################### TEST #####################################
 


### PR DESCRIPTION
Having many tags files or having a really big one causes performance issues, so let's disable this functionality by default and let people enable it if they want it.
