### PR TITLE
make the  package work without extra settings for Windows users

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -11,6 +11,8 @@ import os
 import subprocess
 import bisect
 import mmap
+import platform
+import sublime
 
 from os.path import dirname
 
@@ -162,6 +164,10 @@ def resort_ctags(tag_file):
                 fw.write('\t'.join(split))
 
 def build_ctags(cmd, tag_file, env=None):
+    if platform.system() == "Windows":
+        ctags_path = str(sublime.packages_path())+"\\Ctags\\ctags58\\"
+        env = os.environ.copy()
+        env["PATH"] = ";".join([env["PATH"], ctags_path])
     p = subprocess.Popen(cmd, cwd = dirname(tag_file), shell=1, env=env,
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     ret = p.wait()


### PR DESCRIPTION
Signed-off-by: Jack Phil jack.phil@gmail.com

I noticed that you have add the ctags5.8 excutable binary  for windows users. But the users have to add the path to system. So I add some code to make it work without any extra settings. 

The package is portable now.
