### PR TITLE
Compatiblity with Python 3.x (backwards compatible with >= 2.6)

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -181,7 +181,7 @@ def build_ctags(cmd, tag_file, env=None):
 def test_build_ctags__ctags_not_on_path():
     try:
         build_ctags(['ctags.exe -R'], r'C:\Users\nick\AppData\Roaming\Sublime Text 2\Packages\CTags\tags', env={})
-    except Exception, e:
+    except Exception as e:
         print 'OK'
         print e
     else:
@@ -191,7 +191,7 @@ def test_build_ctags__ctags_not_on_path():
 def test_build_ctags__dodgy_command():
     try:
         build_ctags(['ctags', '--arsts'], r'C:\Users\nick\AppData\Roaming\Sublime Text 2\Packages\CTags\tags')
-    except Exception, e:
+    except Exception as e:
         print 'OK'
         print e
     else:


### PR DESCRIPTION
Change syntax for exception handling. This will work in Python 2.6 and newer, as well as any of the Python 3.x series, allowing this plugin to work in Sublime Text 3.
