### PR TITLE
Improve description of ctags package installation on Linux

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -39,9 +39,10 @@ To get a proper copy of ctags, use one of the following options:
 
 === Linux ===
 
-To get a proper copy of ctags:
-* In a terminal session:
-{{{sudo apt-get install ctags}}}
+To get a proper copy of ctags install package {{{ctags}}} via normal package installer
+(works on all Debian, SuSE, and Fedora derived distros including Ubuntu, RHEL,
+CentOS, SLES, SLED, also Maegia, Mandriva, Arch Linux and others)
+
 
 === Windows ===
 


### PR DESCRIPTION
Expect that every user of any Linux distro has `apt-get` is a bit arrogant towards non-Debian distros.
However, it is not necessary because all enlisted distros (and many others I am sure, but I haven't
checked those) have ctags in a package called just `ctags`.
