### PR TITLE
Fix unreference 'str_err' and the subprocess run of ctags

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -297,7 +297,7 @@ def build_ctags(path, tag_file=None, recursive=False, cmd=None, env=None):
         cmd.append(os.path.join(path, '*'))
 
     # execute the command
-    p = subprocess.Popen(cmd, cwd=cwd, shell=True, env=env,
+    p = subprocess.Popen(cmd, cwd=cwd, shell=False, env=env,
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     ret = p.wait()

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -854,8 +854,9 @@ class RebuildTags(sublime_plugin.TextCommand):
             except EnvironmentError as e:
                 if not isinstance(e.strerror, str):
                     str_err = ' '.join(e.strerror.decode('utf-8').splitlines())
-
-                error_message(str_err)  # show error message
+                else:
+                    str_err = str(e).rstrip()
+                error_message(str_err)  # show error_message
                 return
 
             tags_built(result)


### PR DESCRIPTION
Reworked #170 after a review with @EdVanDance
