### PR TITLE
fix awk cmd execute wrong in non-windows platform. fix #158

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -899,7 +899,12 @@ class CTagsAutoComplete(sublime_plugin.EventListener):
                 if not (view.window().folders() and os.path.exists(tags_path)):
                     return tags
 
-                f = os.popen("awk \"{ print $1 }\" \"" + tags_path + "\"")
+                if sublime.platform() == "windows":
+                    prefix = ""
+                else:
+                    prefix = "\\"
+
+                f = os.popen("awk \"{ print "+prefix+"$1 }\" \"" + tags_path + "\"")
 
                 for i in f.readlines():
                     tags.append([i.strip()])


### PR DESCRIPTION
@stephenfin @nodtem66
fix https://github.com/SublimeText/CTags/pull/158
Because on osx or linux, shell parse $1 in double quotes instead of passing it to awk.
see http://superuser.com/questions/178425/awk-doesnt-work-when-inside-double-quotes
