### PR TITLE
README: Fix package name for Debian et al.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ To install ctags use your package manager.
 
 * For Debian-based systems (Ubuntu, Mint, etc.)::
 
-    sudo apt-get install ctags
+    sudo apt-get install exuberant-ctags
 
 * For Red Hat-based systems (Red Hat, Fedora, CentOS)::
 


### PR DESCRIPTION
In Debian-based distributions the CTags package is called [exuberant-ctags](http://packages.debian.org/stable/exuberant-ctags), just to prevent some confusion…
