### PR TITLE
Fix a bug when utilizing additional search paths for tags files.

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -256,7 +256,7 @@ def get_alternate_tags_paths(view, tags_file):
         for (selector, platform), path in setting('extra_tag_paths'):
             if view.match_selector(view.sel()[0].begin(), selector):
                 if sublime.platform() == platform:
-                    search_paths.append(path)
+                    search_paths.append(os.path.join(path, setting('tag_file')))
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
Issue manifested as a python exception trying to open a directory as a file when 'extra_tag_paths' is non-empty. This was caused by the code that examines the search paths to assume all searchs paths lead to a fully qualified file.

The fix is to do exaclty that by adding the tag_file setting to the end.  This will need to be changed in order to support multiple tag filenames.
