### PR TITLE
Fix a bug "WinError 6"

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -298,7 +298,8 @@ def build_ctags(path, tag_file=None, recursive=False, cmd=None, env=None):
 
     # execute the command
     p = subprocess.Popen(cmd, cwd=cwd, shell=False, env=env,
-                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                         stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
 
     ret = p.wait()
 


### PR DESCRIPTION
https://github.com/SublimeText/CTags/issues/192

I use Windows 7 x64.

When I run command "Rebuild Tags" http://i.imgur.com/rA6VoPp.png , and choose "All Open Folders" http://i.imgur.com/WtT5ejb.png , I get error - "WinError 6" http://i.imgur.com/g1xVFHQ.png

This commit fix this problem for me.
