### PR TITLE
Changes to be committed:

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -473,12 +473,12 @@ class TagFile(object):
             leftIndex = bisect.bisect_left(self, key)
             if exact_match:
                 result = self[leftIndex]
-                while result[result.column] == key:
+                while result.line and result[result.column] == key:
                     yield(result)
                     result = Tag(self.mapped.readline().strip(), self.column)
             else:
                 result = self[leftIndex]
-                while result[result.column].startswith(key):
+                while result.line and result[result.column].startswith(key):
                     yield(result)
                     result = Tag(self.mapped.readline().strip(), self.column)
 


### PR DESCRIPTION
```
modified:   ctags.py
```

Added checks to prevent the search for tags from returning the blank
line at the end of the tag file as a tag.

This fixes a bug that is manifested when searching for tags in the file
(Alt+S) that happens to appear last in the '.tags_sorted_by_file' file.

Solves issue #181 
