### PR TITLE
Additional options argument was missing from a call to build_ctags

### DIFF
--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -15,7 +15,7 @@
     "recursive" : true,
 
     // Additional options to pass to ctags
-    "additional_options" : "",
+    "opts" : "",
 
     // Default read/write location of the tags file
     "tag_file" : ".tags",

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -549,9 +549,10 @@ def show_build_panel(view):
             command = setting('command')
             recursive = setting('recursive')
             tag_file = setting('tag_file')
+            opts = setting('opts')
 
             rebuild_tags = RebuildTags(False)
-            rebuild_tags.build_ctags(paths, command, tag_file, recursive)
+            rebuild_tags.build_ctags(paths, command, tag_file, recursive, opts)
 
     view.window().show_quick_panel(display, on_select)
 


### PR DESCRIPTION
- Added the missing opts variable in a call to build_ctags
- Fixed an inconsistent option name 'additional_options' to 'opts'
