### PR TITLE
Add missing icon parameter to add_regions

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -11,7 +11,6 @@ import re
 import string
 import threading
 import subprocess
-import sys
 
 from itertools import chain
 from operator import itemgetter as iget


### PR DESCRIPTION
The missing parameter lead to the error: ValueError("icon must be a string")
Resolves: #229
