### PR TITLE
Fix accidentally using a symbol as a format string.

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -409,7 +409,7 @@ def format_tag_for_quickopen(tag, show_path=True):
             f += string.Template(
                 '    %($field)s$punct%(symbol)s').substitute(locals())
 
-    format = [(f or tag.symbol) % tag, tag.ex_command]
+    format = [f % tag if f else tag.symbol, tag.ex_command]
     format[1] = format[1].strip()
 
     if show_path:


### PR DESCRIPTION
If the symbol happens to contain a percent (%), the following happend:

```
File "$HOME/.config/sublime-text-3/Packages/CTags/ctagsplugin.py", line 412, in format_tag_for_quickopen
  format = [(f or tag.symbol) % tag, tag.ex_command]
```

  ValueError: incomplete format
