### PR TITLE
for Non-UTF8 charset

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -358,11 +358,11 @@ def resort_ctags(tag_file):
     """
     keys = {}
 
-    with codecs.open(tag_file, encoding='utf-8', errors='ignore') as fh:
+    with codecs.open(tag_file, encoding='utf-8', errors='replace') as fh:
         for line in fh:
             keys.setdefault(line.split('\t')[FILENAME], []).append(line)
 
-    with codecs.open(tag_file+'_sorted_by_file', 'w', encoding='utf-8', errors='ignore') as fw:
+    with codecs.open(tag_file+'_sorted_by_file', 'w', encoding='utf-8', errors='replace') as fw:
         for k in sorted(keys):
             for line in keys[k]:
                 split = line.split('\t')

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -311,6 +311,8 @@ def find_with_scope(view, pattern, scope, start_pos=0, cond=True, flags=0):
     max_pos = view.size()
 
     while start_pos < max_pos:
+        estrs = pattern.split('\ufffd')
+        if(len(estrs)>1):pattern = estrs[0]
         f = view.find(pattern, start_pos, flags)
 
         if not f or view.match_selector(f.begin(), scope) is cond:


### PR DESCRIPTION
XXX = 1 #中文
if the line contains Non UTF8 character, Ctags can't jump to XXX.
'replace' causes the official Unicode replacement character, U+FFFD, to be used to replace input characters which cannot be decoded.
