### PR TITLE
Make tag building error dialog optional.

### DIFF
--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -101,5 +101,8 @@
     // When enabled, searched symbols will be highlighted when found. This
     // can be irritating in some instances, e.g. when in Vintage mode. In
     // these cases, setting this to false will disable this highlighting.
-    "select_searched_symbol": true
+    "select_searched_symbol": true,
+
+    // Set to false to not open an error dialog while tags are building
+    "display_rebuilding_message": true
 }

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -602,7 +602,9 @@ def check_if_building(self, **args):
     Check if ctags are currently being built.
     """
     if RebuildTags.build_ctags.func.running:
-        error_message('Please wait while tags are built')
+        status_message('Tags not available until built')
+        if setting('display_rebuilding_message'):
+            error_message('Please wait while tags are built')
         return False
     return True
 


### PR DESCRIPTION
Encountering this issue on a larger code base where I occasionally rebuild tags.  During the build process, the right-click menu is unusable as CTags opens an error dialog box: "Please wait while tags are built", which closes the menu.

* Added new setting "display_rebuilding_message" to optionally disable
display of error dialog box while tags are building.
* Added alternative status message to inform user of tag building.