### PR TITLE
Ranking Manager

### DIFF
--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -132,11 +132,11 @@
                               "this" : ["self"]
                             }   
                        },
-        "source.java": //TODO: Add real java settings once testing is over
-                      {  
+        "source.java": 
+                      {  "inherit": "source.js",
                          "member_exp":
                             { 
-                         
+                                "this" : ["this"]
                             }   
                        }
     },

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -101,5 +101,11 @@
     // When enabled, searched symbols will be highlighted when found. This
     // can be irritating in some instances, e.g. when in Vintage mode. In
     // these cases, setting this to false will disable this highlighting.
-    "select_searched_symbol": true
+    "select_searched_symbol": true,
+
+    //scope filter: Tags file may optionally contain tagfield for the scope of the tag.
+    //Ex: item  .\app\utils\fileHelper.js   420;"   vp  lineno:420  scope:420:19-422:9
+    //The re is used to extract  scope:/beginLine:beginCol-endLine:endCol/
+    //Different tags generators may generate this non-standard field in different formats
+    "scope_re": "(\\d.*?):(\\d.*?)-(\\d.*?):(\\d.*?)"
 }

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -109,11 +109,11 @@
         "splitters" : [".","::","->"],
         "source.js": { "member_exp":
                         { "chars" : "[A-Za-z0-9_$]",
-                          "splitters" : ["."], 
-                          "open"  : ["{","[","("],
-                          "close" : ["}", "]" , ")"], //close[i] must match open[i]
-                          "ignore" : ["&", "|" , "?" ,":" , "!", "'" , "=","\""],
-                          "stop"   : ["\\s"], 
+                          "splitters" : ["\\."], 
+                          "open"  : ["\\{","\\[","\\("],
+                          "close" : ["\\}", "\\]" , "\\)"], //close[i] must match open[i]
+                          "ignore" : ["&", "\\|" , "\\?" ,":" , "\\!", "'" , "=","\""],
+                          "stop"   : ["\\s",","], 
                           "this" : ["this", "me", "self", "that"]
                          }   
                       },
@@ -121,7 +121,7 @@
                       {  "inherit": "source.js", //python settings inherit JavaScript, with some overrides
                          "member_exp":
                             { 
-                              "ignore" : ["and", "or" , "not" ,":" , "!", "'" ,"=", "\""],                     
+                              "ignore" : ["\\sand\\s", "\\sor\\s" , "\\snot\\s" ,":" , "\\!", "'" ,"=", "\""],                     
                               "this" : ["self"]
                             }   
                        }

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -103,7 +103,7 @@
     // these cases, setting this to false will disable this highlighting.
     "select_searched_symbol": true,
  
-    //Per-language syntax regex and character sets (used by Rank Manager)
+    //Per-language syntax regex and character sets (used by Rank Manager )
     //Ex: Python 'and' ignore exp --> '\sand\s' - it must have whitespace around it so it is not part of real name: gates.Nand.evaluate() 
     "language_syntax": {
         "splitters" : [".","::","->"],

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -115,6 +115,13 @@
                           "ignore" : ["&", "\\|" , "\\?" ,":" , "\\!", "'" , "=","\""],
                           "stop"   : ["\\s",","], 
                           "this" : ["this", "me", "self", "that"]
+                         },
+
+                         "reference_types":
+                         {
+                              "__symbol__(\\.call|\\.apply){0,1}\\s*?\\(" : ["f","fa"],
+                              "\\.fire\\s*?\\(\\s*?\\[\\'\"]__symbol__\\[\\'\"\\]" : ["eventHandler"] 
+
                          }   
                       },
         "source.python": 
@@ -123,6 +130,13 @@
                             { 
                               "ignore" : ["\\sand\\s", "\\sor\\s" , "\\snot\\s" ,":" , "\\!", "'" ,"=", "\""],                     
                               "this" : ["self"]
+                            }   
+                       },
+        "source.java": //TODO: Add real java settings once testing is over
+                      {  
+                         "member_exp":
+                            { 
+                         
                             }   
                        }
     },

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -102,8 +102,8 @@
     // can be irritating in some instances, e.g. when in Vintage mode. In
     // these cases, setting this to false will disable this highlighting.
     "select_searched_symbol": true,
-
-    //Per-language syntax regex and character sets
+ 
+    //Per-language syntax regex and character sets (used by Rank Manager)
     //Ex: Python 'and' ignore exp --> '\sand\s' - it must have whitespace around it so it is not part of real name: gates.Nand.evaluate() 
     "language_syntax": {
         "splitters" : [".","::","->"],

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -141,6 +141,13 @@
                             { 
                                 "this" : ["this"]
                             }   
+                       },
+        "source.cs": 
+                      {  "inherit": "source.js",
+                         "member_exp":
+                            { 
+                                "this" : ["this"]
+                            }   
                        }
     },
 

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -103,6 +103,23 @@
     // these cases, setting this to false will disable this highlighting.
     "select_searched_symbol": true,
 
+    //Per-language syntax regex and character sets
+    //Ex: Python 'and' ignore exp --> '\sand\s' - it must have whitespace around it so it is not part of real name: gates.Nand.evaluate() 
+    "language_syntax": {
+        "splitters" : [".","::","->"],
+        "source.js": { "member_exp":
+                        { "chars" : "[A-Za-z0-9_$]",
+                          "splitters" : ["."], 
+                          "open"  : ["{","[","("],
+                          "close" : ["}", "]" , ")"], //close[i] must match open[i]
+                          "ignore" : ["&", "|" , "?" ,":" , "!", "'" , "\""],
+                          "stop"   : ["\\s"], 
+                          "this" : ["this", "me", "self", "that"]
+                         }   
+                     }
+    },
+
+
     //scope filter: Tags file may optionally contain tagfield for the scope of the tag.
     //Ex: item  .\app\utils\fileHelper.js   420;"   vp  lineno:420  scope:420:19-422:9
     //The re is used to extract  scope:/beginLine:beginCol-endLine:endCol/

--- a/CTags.sublime-settings
+++ b/CTags.sublime-settings
@@ -112,11 +112,19 @@
                           "splitters" : ["."], 
                           "open"  : ["{","[","("],
                           "close" : ["}", "]" , ")"], //close[i] must match open[i]
-                          "ignore" : ["&", "|" , "?" ,":" , "!", "'" , "\""],
+                          "ignore" : ["&", "|" , "?" ,":" , "!", "'" , "=","\""],
                           "stop"   : ["\\s"], 
                           "this" : ["this", "me", "self", "that"]
                          }   
-                     }
+                      },
+        "source.python": 
+                      {  "inherit": "source.js", //python settings inherit JavaScript, with some overrides
+                         "member_exp":
+                            { 
+                              "ignore" : ["and", "or" , "not" ,":" , "!", "'" ,"=", "\""],                     
+                              "this" : ["self"]
+                            }   
+                       }
     },
 
 

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -339,8 +339,9 @@ def scroll_to_tag(view, tag, hook=None):
                 do_find = False
 
         if do_find:
+            search_symbol = tag.get('def_symbol',tag.symbol)
             symbol_region = view.find(
-                escape_regex(tag.symbol) + r"(?:[^_]|$)", look_from, 0)
+                escape_regex(search_symbol) + r"(?:[^_]|$)", look_from, 0)
 
         if do_find and symbol_region:
             # Using reversed symbol_region so cursor stays in front of the

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -766,10 +766,11 @@ class JumpToDefinition:
         @prepare_for_quickpanel()
         def sorted_tags():
             # Scope Filter: If symbol matches at least 1 local scope tag - assume they hides non-scope and global scope tags. 
-            # If non local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard 
+            # If no local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard 
             # the local-scope - because they are not locals of the current position                                
+            # If object-receiver (someobj.symbol) --> refer to as global tag --> filter out local-scope tags
             (in_scope,no_scope) = scope_filter(tags.get(symbol, []))
-            if (len(in_scope) > 0):
+            if (len(setMbrGrams) ==0 and len(in_scope) > 0):
                 p_tags = in_scope
             else:                
                 p_tags = no_scope

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -508,7 +508,7 @@ def show_build_panel(view):
             ['All Open Folders', '; '.join(
                 ['\'{0}\''.format(os.path.split(x)[1])
                  for x in view.window().folders()])])
-        # append options to build for each open folder
+        # Append options to build for each open folder 
         display.extend(
             [[os.path.split(x)[1], x] for x in view.window().folders()])
 

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -693,11 +693,11 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
                     print('non-matching brackets at the same nesting level: %s %s' % (tokCloseCur,tokClose))
                     break
                 insideExp = False
-            elif re.match(reIgnore,cur):
-                pass 
             # If white space --> stop. Do not stop for whitespace inside open-close brackets nested expression
             elif re.match(reStop,cur):
                 if not insideExp: break
+            elif re.match(reIgnore,cur):
+                pass
             else:
                 lstMbr[0:0] = cur
 

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -765,7 +765,7 @@ class SearchForDefinition(sublime_plugin.WindowCommand):
             status_message('Can\'t find any relevant tags file')
             return
 
-        result = JumpToDefinition.run(symbol,None, None,None, view, tags_file)
+        result = JumpToDefinition.run(symbol,None, "",[], view, tags_file)
         show_tag_panel(view, result, True)
 
     def on_change(self, text):

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -19,7 +19,7 @@ from operator import itemgetter as iget
 from collections import defaultdict, deque
 
 # TODO:Debug:Remove Dekel
-import spdb
+#import spdb
 
 try:
     import sublime

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -652,7 +652,7 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
         sym_line = view.substr(view.line(region))
         (row,col) = view.rowcol(region.begin())
         line_to_symbol = sym_line[:col]
- 
+        #print ("line_to_symbol %s" % line_to_symbol)
         source = get_source(view)
         arrMbrParts = Parser.extract_member_exp(line_to_symbol,source)
         return JumpToDefinition.run(symbol, region, sym_line,arrMbrParts, view, tags_file)

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -18,7 +18,7 @@ from itertools import chain
 from operator import itemgetter as iget
 from collections import defaultdict, deque
 
-# TODO:Debug:Remove Dekel
+# TODO:Debug:Remove Dekel- comment
 #import spdb
 
 try:

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -1,5 +1,5 @@
 """
-A ctags plugin for Sublime Text 2/3. 
+A ctags plugin for Sublime Text 2/3.
 """
 
 import functools
@@ -59,7 +59,6 @@ RUBY_SPECIAL_ENDINGS = r'\?|!'
 ON_LOAD = sublime_plugin.all_callbacks['on_load']
 
 
-
 #
 # Functions
 #
@@ -71,6 +70,7 @@ def select(view, region):
     sel_set.add(region)
     sublime.set_timeout(functools.partial(view.show_at_center, region), 1)
 
+
 def in_main(f):
     @functools.wraps(f)
     def done_in_main(*args, **kw):
@@ -79,6 +79,8 @@ def in_main(f):
     return done_in_main
 
 # TODO: allow thread per tag file. That makes more sense.
+
+
 def threaded(finish=None, msg='Thread already running'):
     def decorator(func):
         func.running = 0
@@ -111,6 +113,7 @@ def threaded(finish=None, msg='Thread already running'):
         return threaded
 
     return decorator
+
 
 def on_load(path=None, window=None, encoded_row_col=True, begin_edit=False):
     """
@@ -176,6 +179,7 @@ def on_load(path=None, window=None, encoded_row_col=True, begin_edit=False):
 
     return wrapper
 
+
 def find_tags_relative_to(path, tag_file):
     """
     Find the tagfile relative to a file path.
@@ -199,6 +203,7 @@ def find_tags_relative_to(path, tag_file):
             dirs.pop()
 
     return None
+
 
 def get_alternate_tags_paths(view, tags_file):
     """
@@ -227,7 +232,9 @@ def get_alternate_tags_paths(view, tags_file):
         for (selector, platform), path in setting('extra_tag_paths'):
             if view.match_selector(view.sel()[0].begin(), selector):
                 if sublime.platform() == platform:
-                    search_paths.append(os.path.join(path, setting('tag_file')))
+                    search_paths.append(
+                        os.path.join(
+                            path, setting('tag_file')))
     except Exception as e:
         print(e)
 
@@ -255,6 +262,7 @@ def get_alternate_tags_paths(view, tags_file):
             ret.append(path)
     return ret
 
+
 def get_common_ancestor_folder(path, folders):
     """
     Get common ancestor for a file and a list of folders.
@@ -280,11 +288,12 @@ def get_common_ancestor_folder(path, folders):
 
 # Scrolling functions
 
+
 def find_with_scope(view, pattern, scope, start_pos=0, cond=True, flags=0):
     max_pos = view.size()
     while start_pos < max_pos:
         estrs = pattern.split(r'\ufffd')
-        if(len(estrs)>1):
+        if(len(estrs) > 1):
             pattern = estrs[0]
         f = view.find(pattern, start_pos, flags)
 
@@ -295,9 +304,11 @@ def find_with_scope(view, pattern, scope, start_pos=0, cond=True, flags=0):
 
     return f
 
+
 def find_source(view, pattern, start_at, flags=sublime.LITERAL):
     return find_with_scope(view, pattern, 'string',
                            start_at, False, flags)
+
 
 def follow_tag_path(view, tag_path, pattern):
     regions = [sublime.Region(0, 0)]
@@ -324,20 +335,21 @@ def follow_tag_path(view, tag_path, pattern):
 
     return pattern_region.begin() - 1 if pattern_region else None
 
+
 def scroll_to_tag(view, tag, hook=None):
     @on_load(os.path.join(tag.root_dir, tag.filename))
     def and_then(view):
         do_find = True
 
         if tag.ex_command.isdigit():
-            look_from = view.text_point(int(tag.ex_command)-1, 0)
+            look_from = view.text_point(int(tag.ex_command) - 1, 0)
         else:
             look_from = follow_tag_path(view, tag.tag_path, tag.ex_command)
             if not look_from:
                 do_find = False
 
         if do_find:
-            search_symbol = tag.get('def_symbol',tag.symbol)
+            search_symbol = tag.get('def_symbol', tag.symbol)
             symbol_region = view.find(
                 escape_regex(search_symbol) + r"(?:[^_]|$)", look_from, 0)
 
@@ -356,6 +368,7 @@ def scroll_to_tag(view, tag, hook=None):
             hook(view)
 
 # Formatting helper functions
+
 
 def format_tag_for_quickopen(tag, show_path=True):
     """
@@ -384,6 +397,7 @@ def format_tag_for_quickopen(tag, show_path=True):
 
     return format_
 
+
 def prepare_for_quickpanel(formatter=format_tag_for_quickopen):
     """
     Prepare list of matching ctags for the quickpanel.
@@ -404,6 +418,7 @@ def prepare_for_quickpanel(formatter=format_tag_for_quickopen):
     return compile_lists
 
 # File collection helper functions
+
 
 def get_rel_path_to_source(path, tag_file, multiple=True):
     """
@@ -442,6 +457,7 @@ def get_current_file_suffix(path):
 #
 
 # JumpPrev Commands
+
 
 class JumpPrev(sublime_plugin.WindowCommand):
     """
@@ -484,6 +500,7 @@ class JumpPrev(sublime_plugin.WindowCommand):
 
 # CTags commands
 
+
 def show_build_panel(view):
     """
     Handle build ctags command.
@@ -506,7 +523,7 @@ def show_build_panel(view):
             ['All Open Folders', '; '.join(
                 ['\'{0}\''.format(os.path.split(x)[1])
                  for x in view.window().folders()])])
-        # Append options to build for each open folder 
+        # Append options to build for each open folder
         display.extend(
             [[os.path.split(x)[1], x] for x in view.window().folders()])
 
@@ -526,6 +543,7 @@ def show_build_panel(view):
             rebuild_tags.build_ctags(paths, command, tag_file, recursive, opts)
 
     view.window().show_quick_panel(display, on_select)
+
 
 def show_tag_panel(view, result, jump_directly):
     """
@@ -553,6 +571,7 @@ def show_tag_panel(view, result, jump_directly):
         else:
             view.window().show_quick_panel(display, on_select)
 
+
 def ctags_goto_command(jump_directly=False):
     """
     Decorator to goto a ctag entry.
@@ -575,6 +594,7 @@ def ctags_goto_command(jump_directly=False):
         return command
     return wrapper
 
+
 def check_if_building(self, **args):
     """
     Check if ctags are currently being built.
@@ -594,9 +614,9 @@ class JumpToDefinition:
     Provider for NavigateToDefinition and SearchForDefinition commands.
     """
     @staticmethod
-    def run(symbol,region,sym_line, mbrParts, view, tags_file):
-        #print('JumpToDefinition')
-         
+    def run(symbol, region, sym_line, mbrParts, view, tags_file):
+        # print('JumpToDefinition')
+
         tags = {}
         for tags_file in get_alternate_tags_paths(view, tags_file):
             with TagFile(tags_file, SYMBOL) as tagfile:
@@ -608,8 +628,8 @@ class JumpToDefinition:
         if not tags:
             return status_message('Can\'t find "%s"' % symbol)
 
-        rankmgr = RankMgr(region, mbrParts, view,symbol,sym_line)
-        
+        rankmgr = RankMgr(region, mbrParts, view, symbol, sym_line)
+
         @prepare_for_quickpanel()
         def sorted_tags():
             taglist = tags.get(symbol, [])
@@ -619,6 +639,7 @@ class JumpToDefinition:
             return p_tags
 
         return sorted_tags
+
 
 class NavigateToDefinition(sublime_plugin.TextCommand):
     """
@@ -635,8 +656,7 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
 
     def is_visible(self):
         return setting('show_context_menus')
-    
-        
+
     @ctags_goto_command(jump_directly=True)
     def run(self, view, args, tags_file):
         region = view.sel()[0]
@@ -645,19 +665,29 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
 
             # handle special line endings for Ruby
             language = view.settings().get('syntax')
-            endings = view.substr(sublime.Region(region.end(), region.end()+1))
+            endings = view.substr(
+                sublime.Region(
+                    region.end(),
+                    region.end() + 1))
 
             if 'Ruby' in language and self.endings.match(endings):
-                region = sublime.Region(region.begin(), region.end()+1)
+                region = sublime.Region(region.begin(), region.end() + 1)
         symbol = view.substr(region)
-     
+
         sym_line = view.substr(view.line(region))
-        (row,col) = view.rowcol(region.begin())
+        (row, col) = view.rowcol(region.begin())
         line_to_symbol = sym_line[:col]
         #print ("line_to_symbol %s" % line_to_symbol)
         source = get_source(view)
-        arrMbrParts = Parser.extract_member_exp(line_to_symbol,source)
-        return JumpToDefinition.run(symbol, region, sym_line,arrMbrParts, view, tags_file)
+        arrMbrParts = Parser.extract_member_exp(line_to_symbol, source)
+        return JumpToDefinition.run(
+            symbol,
+            region,
+            sym_line,
+            arrMbrParts,
+            view,
+            tags_file)
+
 
 class SearchForDefinition(sublime_plugin.WindowCommand):
     """
@@ -684,7 +714,7 @@ class SearchForDefinition(sublime_plugin.WindowCommand):
             status_message('Can\'t find any relevant tags file')
             return
 
-        result = JumpToDefinition.run(symbol,None, "",[], view, tags_file)
+        result = JumpToDefinition.run(symbol, None, "", [], view, tags_file)
         show_tag_panel(view, result, True)
 
     def on_change(self, text):
@@ -696,6 +726,7 @@ class SearchForDefinition(sublime_plugin.WindowCommand):
 # Show Symbol commands
 
 tags_cache = defaultdict(dict)
+
 
 class ShowSymbols(sublime_plugin.TextCommand):
     """
@@ -773,6 +804,7 @@ class ShowSymbols(sublime_plugin.TextCommand):
 
 # Rebuild CTags commands
 
+
 class RebuildTags(sublime_plugin.TextCommand):
     """
     Provider for the ``rebuild_tags`` command.
@@ -780,6 +812,7 @@ class RebuildTags(sublime_plugin.TextCommand):
     Command (re)builds tag files for the open file(s) or folder(s), reading
     relevant settings from the settings file.
     """
+
     def run(self, edit, **args):
         """Handler for ``rebuild_tags`` command"""
         paths = []
@@ -847,12 +880,14 @@ class RebuildTags(sublime_plugin.TextCommand):
                     str_err = ' '.join(
                         e.output.decode('windows-1252').splitlines())
                 else:
-                    str_err = e.output.decode(locale.getpreferredencoding()).rstrip()
+                    str_err = e.output.decode(
+                        locale.getpreferredencoding()).rstrip()
 
                 error_message(str_err)
                 return
             except Exception as e:
-                error_message("An unknown error occured.\nCheck the console for info.")
+                error_message(
+                    "An unknown error occured.\nCheck the console for info.")
                 raise e
 
             tags_built(result)
@@ -860,6 +895,7 @@ class RebuildTags(sublime_plugin.TextCommand):
         GetAllCTagsList.ctags_list = []  # clear the cached ctags list
 
 # Autocomplete commands
+
 
 class GetAllCTagsList():
     """
@@ -870,7 +906,9 @@ class GetAllCTagsList():
     def __init__(self, list):
         self.ctags_list = list
 
+
 class CTagsAutoComplete(sublime_plugin.EventListener):
+
     def on_query_completions(self, view, prefix, locations):
         if setting('autocomplete'):
             prefix = prefix.strip().lower()
@@ -899,7 +937,8 @@ class CTagsAutoComplete(sublime_plugin.EventListener):
                 else:
                     prefix = "\\"
 
-                f = os.popen("awk \"{ print "+prefix+"$1 }\" \"" + tags_path + "\"")
+                f = os.popen(
+                    "awk \"{ print " + prefix + "$1 }\" \"" + tags_path + "\"")
 
                 for i in f.readlines():
                     tags.append([i.strip()])
@@ -910,12 +949,12 @@ class CTagsAutoComplete(sublime_plugin.EventListener):
                 GetAllCTagsList.ctags_list = tags
                 results = [sublist for sublist in GetAllCTagsList.ctags_list
                            if sublist[0].lower().startswith(prefix)]
-                results = list(set(results).union(set(sub_results)))
-                results.sort()
+                results = sorted(set(results).union(set(sub_results)))
 
                 return results
 
 # Test CTags commands
+
 
 class TestCtags(sublime_plugin.TextCommand):
     routine = None

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -97,6 +97,15 @@ def concat_re(reList,escape=True,wrapCapture=False):
         ret = "(" + ret + ")"
     return ret
 
+def dict_extend(dct, base):
+        if not dct: dct = {}
+        if base:
+            deriv = base
+            deriv.update(dct)
+        else:
+            deriv = dct
+        return deriv
+
 def escape_regex(s):
     return RE_SPECIAL_CHARS.sub(lambda m: '\\%s' % m.group(1), s)
 
@@ -815,6 +824,10 @@ class NavigateToDefinition(sublime_plugin.TextCommand):
     def extract_member_exp(self,line_to_symbol,source):    
         lang = setting('language_syntax').get(source)
         if lang is None: return line_to_symbol
+        print('lang.get(inherit)=%s' %  lang.get('inherit'))
+        base = setting('language_syntax').get(lang.get('inherit'))
+        lang = dict_extend(lang ,base)
+        
         # Get per-language syntax regex of brackets, splitters etc.
         mbr_exp = lang.get('member_exp')
         if mbr_exp is None: return line_to_symbol

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -107,9 +107,11 @@ def get_lang_setting(source):
     A language can inherit its settings from another language, overidding as needed. 
     """
     lang = setting('language_syntax').get(source)
-    if lang is None: return line_to_symbol
-    base = setting('language_syntax').get(lang.get('inherit'))
-    lang = dict_extend(lang ,base)
+    if lang is not None:
+        base = setting('language_syntax').get(lang.get('inherit'))
+        lang = dict_extend(lang ,base)
+    else:
+        lang = {}
     return lang
 
 

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -31,6 +31,7 @@ def get_settings():
     """
     return sublime.load_settings("CTags.sublime-settings")
 
+
 def get_setting(key, default=None):
     """
     Load individual setting.
@@ -43,7 +44,9 @@ def get_setting(key, default=None):
     return get_settings().get(key, default)
 
 setting = get_setting
-def concat_re(reList,escape=False,wrapCapture=False):
+
+
+def concat_re(reList, escape=False, wrapCapture=False):
     """
     concat list of regex into a single regex, used by re.split
     wrapCapture - if true --> adds () around the result regex --> split will keep the splitters in its output array.
@@ -53,20 +56,23 @@ def concat_re(reList,escape=False,wrapCapture=False):
         ret = "(" + ret + ")"
     return ret
 
+
 def dict_extend(dct, base):
-        if not dct: dct = {}
-        if base:
-            deriv = base
-            deriv = merge_two_dicts_deep(deriv,dct)
-        else:
-            deriv = dct
-        return deriv
+    if not dct:
+        dct = {}
+    if base:
+        deriv = base
+        deriv = merge_two_dicts_deep(deriv, dct)
+    else:
+        deriv = dct
+    return deriv
+
 
 def merge_two_dicts_shallow(x, y):
     """
-    Given two dicts, merge them into a new dict as a shallow copy. 
+    Given two dicts, merge them into a new dict as a shallow copy.
     y members overwrite x members with the same keys.
-    """        
+    """
     z = x.copy()
     z.update(y)
     return z
@@ -74,13 +80,14 @@ def merge_two_dicts_shallow(x, y):
 
 def merge_two_dicts_deep(a, b, path=None):
     "Merges b into a including sub-dictionaries - recursive"
-    if path is None: path = []
+    if path is None:
+        path = []
     for key in b:
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
                 merge_two_dicts_deep(a[key], b[key], path + [str(key)])
             elif a[key] == b[key]:
-                pass # same leaf value
+                pass  # same leaf value
             else:
                 a[key] = b[key]
         else:
@@ -90,26 +97,30 @@ def merge_two_dicts_deep(a, b, path=None):
 RE_SPECIAL_CHARS = re.compile(
     '(\\\\|\\*|\\+|\\?|\\||\\{|\\}|\\[|\\]|\\(|\\)|\\^|\\$|\\.|\\#|\\ )')
 
+
 def escape_regex(s):
     return RE_SPECIAL_CHARS.sub(lambda m: '\\%s' % m.group(1), s)
-    
+
+
 def get_source(view):
     """
     return the language used in current caret or selection location
     """
-    scope_name = view.scope_name(view.sel()[0].begin()) # ex: 'source.python meta.function-call.python '
-    source = re.split(' ',scope_name)[0] # ex: 'source.python'
+    scope_name = view.scope_name(
+        view.sel()[0].begin())  # ex: 'source.python meta.function-call.python '
+    source = re.split(' ', scope_name)[0]  # ex: 'source.python'
     return source
+
 
 def get_lang_setting(source):
     """
     given source (ex: 'source.python') --> return its language_syntax settings.
-    A language can inherit its settings from another language, overidding as needed. 
+    A language can inherit its settings from another language, overidding as needed.
     """
     lang = setting('language_syntax').get(source)
     if lang is not None:
         base = setting('language_syntax').get(lang.get('inherit'))
-        lang = dict_extend(lang ,base)
+        lang = dict_extend(lang, base)
     else:
         lang = {}
     return lang

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -102,9 +102,12 @@ def get_source(view):
     return source
 
 def get_lang_setting(source):
+    """
+    given source (ex: 'source.python') --> return its language_syntax settings.
+    A language can inherit its settings from another language, overidding as needed. 
+    """
     lang = setting('language_syntax').get(source)
     if lang is None: return line_to_symbol
-    print('lang.get(inherit)=%s' %  lang.get('inherit'))
     base = setting('language_syntax').get(lang.get('inherit'))
     lang = dict_extend(lang ,base)
     return lang

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -92,6 +92,22 @@ RE_SPECIAL_CHARS = re.compile(
 
 def escape_regex(s):
     return RE_SPECIAL_CHARS.sub(lambda m: '\\%s' % m.group(1), s)
+    
+def get_source(view):
+    """
+    return the language used in current caret or selection location
+    """
+    scope_name = view.scope_name(view.sel()[0].begin()) # ex: 'source.python meta.function-call.python '
+    source = re.split(' ',scope_name)[0] # ex: 'source.python'
+    return source
+
+def get_lang_setting(source):
+    lang = setting('language_syntax').get(source)
+    if lang is None: return line_to_symbol
+    print('lang.get(inherit)=%s' %  lang.get('inherit'))
+    base = setting('language_syntax').get(lang.get('inherit'))
+    lang = dict_extend(lang ,base)
+    return lang
 
 
 def compile_filters(view):

--- a/helpers/common.py
+++ b/helpers/common.py
@@ -1,0 +1,103 @@
+"""
+common utilities used by all ctags modules
+"""
+import re
+import sys
+import os
+
+# Helper functions
+
+try:
+    import sublime
+    import sublime_plugin
+    from sublime import status_message, error_message
+
+    # hack the system path to prevent the following issue in ST3
+    #     ImportError: No module named 'ctags'
+    sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+except ImportError:  # running tests
+    from tests.sublime_fake import sublime
+    from tests.sublime_fake import sublime_plugin
+
+    sys.modules['sublime'] = sublime
+    sys.modules['sublime_plugin'] = sublime_plugin
+
+
+def get_settings():
+    """
+    Load settings.
+
+    :returns: dictionary containing settings
+    """
+    return sublime.load_settings("CTags.sublime-settings")
+
+def get_setting(key, default=None):
+    """
+    Load individual setting.
+
+    :param key: setting key to get value for
+    :param default: default value to return if no value found
+
+    :returns: value for ``key`` if ``key`` exists, else ``default``
+    """
+    return get_settings().get(key, default)
+
+setting = get_setting
+def concat_re(reList,escape=False,wrapCapture=False):
+    """
+    concat list of regex into a single regex, used by re.split
+    wrapCapture - if true --> adds () around the result regex --> split will keep the splitters in its output array.
+    """
+    ret = "|".join((re.escape(spl) if escape else spl) for spl in reList)
+    if (wrapCapture):
+        ret = "(" + ret + ")"
+    return ret
+
+def dict_extend(dct, base):
+        if not dct: dct = {}
+        if base:
+            deriv = base
+            deriv = merge_two_dicts_deep(deriv,dct)
+        else:
+            deriv = dct
+        return deriv
+
+def merge_two_dicts_shallow(x, y):
+    """
+    Given two dicts, merge them into a new dict as a shallow copy. 
+    y members overwrite x members with the same keys.
+    """        
+    z = x.copy()
+    z.update(y)
+    return z
+
+
+def merge_two_dicts_deep(a, b, path=None):
+    "Merges b into a including sub-dictionaries - recursive"
+    if path is None: path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge_two_dicts_deep(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass # same leaf value
+            else:
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a
+
+RE_SPECIAL_CHARS = re.compile(
+    '(\\\\|\\*|\\+|\\?|\\||\\{|\\}|\\[|\\]|\\(|\\)|\\^|\\$|\\.|\\#|\\ )')
+
+def escape_regex(s):
+    return RE_SPECIAL_CHARS.sub(lambda m: '\\%s' % m.group(1), s)
+
+
+def compile_filters(view):
+    filters = []
+    for selector, regexes in list(setting('filters', {}).items()):
+        if view.match_selector(view.sel() and view.sel()[0].begin() or 0,
+                               selector):
+            filters.append(regexes)
+    return filters

--- a/ranking/parse.py
+++ b/ranking/parse.py
@@ -1,0 +1,78 @@
+import re
+from helpers.common import *
+
+class Parser:
+    """
+    Parses tag references and tag definitions. Used for ranking
+    """
+    @staticmethod
+    def extract_member_exp(line_to_symbol,source):
+        """
+        Extract receiver object e.g. receiver.mtd() 
+        Strip away brackets and operators.
+        TODO:HIGH: Add base lang defs + Python/Ruby/C++/Java/C#/PHP overrides (should be very similar)
+        TODO: comment and string support (eat as may contain brackets. add them to context - js['prop1']['prop-of-prop1'])
+        """
+        lang = get_lang_setting(source)        
+        # Get per-language syntax regex of brackets, splitters etc.
+        mbr_exp = lang.get('member_exp')
+        if mbr_exp is None: 
+            return [line_to_symbol]
+
+        lstStop = mbr_exp.get('stop',[])
+        if (not lstStop):
+            print('warning!: language has member_exp setting but it is ineffective: Must have "stop" key with array of regex to stop search backward from identifier')
+            return line_to_symbol
+
+        lstClose = mbr_exp.get('close',[])
+        reClose = concat_re(lstClose)
+        lstOpen = mbr_exp.get('open',[])
+        reOpen = concat_re(lstOpen)
+        lstIgnore = mbr_exp.get('ignore',[])
+        reIgnore =  concat_re(lstIgnore)
+        if len(lstOpen) != len(lstClose): print('warning!: extract_member_exp: settings lstOpen must match lstClose')
+        matchOpenClose = dict(zip(lstOpen,lstClose))
+        # Construct | regex from all open and close strings with capture (..)
+        splex = concat_re(lstOpen + lstClose + lstIgnore + lstStop)
+        
+        reStop =  concat_re(lstStop)
+        splex = "({0}|{1})".format(splex,reIgnore)
+        splat = re.split(splex,line_to_symbol)
+        #print('splat=%s' %  splat)
+        #  Stack iter reverse(splat) for detecting unbalanced e.g 'func(obj.yyy' while skipping balanced brackets in getSlow(a && b).mtd()
+        stack = []
+        lstMbr = []
+        insideExp = False
+        for cur in reversed(splat):
+            # Scan backwards from the symbol: If alpha-numeric - keep it. If Closing bracket e.g ] or ) or } --> push into stack
+            if re.match(reClose,cur):
+                stack.append(cur)
+                insideExp = True
+            # If opening bracket --> match it from top-of-stack: If stack empty - stop else If match pop-and-continue else stop scanning + warning
+            elif re.match(reOpen,cur):
+                # '(' with no matching ')' --> func(obj.yyy case --> return obj.yyy
+                if len(stack) == 0:  
+                    break
+                tokClose = stack.pop()
+                tokCloseCur = matchOpenClose.get(cur)
+                if tokClose != tokCloseCur:
+                    print('non-matching brackets at the same nesting level: %s %s' % (tokCloseCur,tokClose))
+                    break
+                insideExp = False
+            # If white space --> stop. Do not stop for whitespace inside open-close brackets nested expression
+            elif re.match(reStop,cur):
+                if not insideExp: break
+            elif re.match(reIgnore,cur):
+                pass
+            else:
+                lstMbr[0:0] = cur
+
+        strMbrExp = "".join(lstMbr)
+        
+        lstSplit = mbr_exp.get('splitters',[])
+        reSplit =  concat_re(lstSplit)
+        arrMbrParts = list(filter(None,re.split(reSplit,strMbrExp))) # Split member deref per-lang (-> and :: in PHP and C++) - use base if not found
+        # print('arrMbrParts=%s' %  arrMbrParts)
+        
+        return arrMbrParts
+    

--- a/ranking/parse.py
+++ b/ranking/parse.py
@@ -1,6 +1,7 @@
 import re
 from helpers.common import *
-
+#import spdb
+#spdb.start()
 class Parser:
     """
     Parses tag references and tag definitions. Used for ranking
@@ -13,7 +14,10 @@ class Parser:
         TODO:HIGH: Add base lang defs + Python/Ruby/C++/Java/C#/PHP overrides (should be very similar)
         TODO: comment and string support (eat as may contain brackets. add them to context - js['prop1']['prop-of-prop1'])
         """
-        lang = get_lang_setting(source)        
+        lang = get_lang_setting(source)
+        if not lang:
+            return [line_to_symbol]
+        
         # Get per-language syntax regex of brackets, splitters etc.
         mbr_exp = lang.get('member_exp')
         if mbr_exp is None: 
@@ -22,7 +26,7 @@ class Parser:
         lstStop = mbr_exp.get('stop',[])
         if (not lstStop):
             print('warning!: language has member_exp setting but it is ineffective: Must have "stop" key with array of regex to stop search backward from identifier')
-            return line_to_symbol
+            return [line_to_symbol]
 
         lstClose = mbr_exp.get('close',[])
         reClose = concat_re(lstClose)

--- a/ranking/parse.py
+++ b/ranking/parse.py
@@ -1,15 +1,17 @@
 import re
 from helpers.common import *
 #import spdb
-#spdb.start()
+# spdb.start()
+
+
 class Parser:
     """
     Parses tag references and tag definitions. Used for ranking
     """
     @staticmethod
-    def extract_member_exp(line_to_symbol,source):
+    def extract_member_exp(line_to_symbol, source):
         """
-        Extract receiver object e.g. receiver.mtd() 
+        Extract receiver object e.g. receiver.mtd()
         Strip away brackets and operators.
         TODO:HIGH: Add base lang defs + Python/Ruby/C++/Java/C#/PHP overrides (should be very similar)
         TODO: comment and string support (eat as may contain brackets. add them to context - js['prop1']['prop-of-prop1'])
@@ -17,66 +19,76 @@ class Parser:
         lang = get_lang_setting(source)
         if not lang:
             return [line_to_symbol]
-        
+
         # Get per-language syntax regex of brackets, splitters etc.
         mbr_exp = lang.get('member_exp')
-        if mbr_exp is None: 
+        if mbr_exp is None:
             return [line_to_symbol]
 
-        lstStop = mbr_exp.get('stop',[])
+        lstStop = mbr_exp.get('stop', [])
         if (not lstStop):
             print('warning!: language has member_exp setting but it is ineffective: Must have "stop" key with array of regex to stop search backward from identifier')
             return [line_to_symbol]
 
-        lstClose = mbr_exp.get('close',[])
+        lstClose = mbr_exp.get('close', [])
         reClose = concat_re(lstClose)
-        lstOpen = mbr_exp.get('open',[])
+        lstOpen = mbr_exp.get('open', [])
         reOpen = concat_re(lstOpen)
-        lstIgnore = mbr_exp.get('ignore',[])
-        reIgnore =  concat_re(lstIgnore)
-        if len(lstOpen) != len(lstClose): print('warning!: extract_member_exp: settings lstOpen must match lstClose')
-        matchOpenClose = dict(zip(lstOpen,lstClose))
+        lstIgnore = mbr_exp.get('ignore', [])
+        reIgnore = concat_re(lstIgnore)
+        if len(lstOpen) != len(lstClose):
+            print('warning!: extract_member_exp: settings lstOpen must match lstClose')
+        matchOpenClose = dict(zip(lstOpen, lstClose))
         # Construct | regex from all open and close strings with capture (..)
         splex = concat_re(lstOpen + lstClose + lstIgnore + lstStop)
-        
-        reStop =  concat_re(lstStop)
-        splex = "({0}|{1})".format(splex,reIgnore)
-        splat = re.split(splex,line_to_symbol)
+
+        reStop = concat_re(lstStop)
+        splex = "({0}|{1})".format(splex, reIgnore)
+        splat = re.split(splex, line_to_symbol)
         #print('splat=%s' %  splat)
-        #  Stack iter reverse(splat) for detecting unbalanced e.g 'func(obj.yyy' while skipping balanced brackets in getSlow(a && b).mtd()
+        # Stack iter reverse(splat) for detecting unbalanced e.g 'func(obj.yyy'
+        # while skipping balanced brackets in getSlow(a && b).mtd()
         stack = []
         lstMbr = []
         insideExp = False
         for cur in reversed(splat):
-            # Scan backwards from the symbol: If alpha-numeric - keep it. If Closing bracket e.g ] or ) or } --> push into stack
-            if re.match(reClose,cur):
+            # Scan backwards from the symbol: If alpha-numeric - keep it. If
+            # Closing bracket e.g ] or ) or } --> push into stack
+            if re.match(reClose, cur):
                 stack.append(cur)
                 insideExp = True
-            # If opening bracket --> match it from top-of-stack: If stack empty - stop else If match pop-and-continue else stop scanning + warning
-            elif re.match(reOpen,cur):
+            # If opening bracket --> match it from top-of-stack: If stack empty
+            # - stop else If match pop-and-continue else stop scanning +
+            # warning
+            elif re.match(reOpen, cur):
                 # '(' with no matching ')' --> func(obj.yyy case --> return obj.yyy
-                if len(stack) == 0:  
+                if len(stack) == 0:
                     break
                 tokClose = stack.pop()
                 tokCloseCur = matchOpenClose.get(cur)
                 if tokClose != tokCloseCur:
-                    print('non-matching brackets at the same nesting level: %s %s' % (tokCloseCur,tokClose))
+                    print(
+                        'non-matching brackets at the same nesting level: %s %s' %
+                        (tokCloseCur, tokClose))
                     break
                 insideExp = False
-            # If white space --> stop. Do not stop for whitespace inside open-close brackets nested expression
-            elif re.match(reStop,cur):
-                if not insideExp: break
-            elif re.match(reIgnore,cur):
+            # If white space --> stop. Do not stop for whitespace inside
+            # open-close brackets nested expression
+            elif re.match(reStop, cur):
+                if not insideExp:
+                    break
+            elif re.match(reIgnore, cur):
                 pass
             else:
                 lstMbr[0:0] = cur
 
         strMbrExp = "".join(lstMbr)
-        
-        lstSplit = mbr_exp.get('splitters',[])
-        reSplit =  concat_re(lstSplit)
-        arrMbrParts = list(filter(None,re.split(reSplit,strMbrExp))) # Split member deref per-lang (-> and :: in PHP and C++) - use base if not found
+
+        lstSplit = mbr_exp.get('splitters', [])
+        reSplit = concat_re(lstSplit)
+        # Split member deref per-lang (-> and :: in PHP and C++) - use base if
+        # not found
+        arrMbrParts = list(filter(None, re.split(reSplit, strMbrExp)))
         # print('arrMbrParts=%s' %  arrMbrParts)
-        
+
         return arrMbrParts
-    

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -40,7 +40,7 @@ class RankMgr:
         self.sym_line = sym_line 
         
         self.lang = get_lang_setting(get_source(view))
-        self.mbr_exp = self.lang.get('member_exp')
+        self.mbr_exp = self.lang.get('member_exp',{})
             
         self.def_filters = compile_definition_filters(view)
 
@@ -105,7 +105,7 @@ class RankMgr:
         """
         # First time - compare current symbol line to the per-language list of regex: Each regex is mapped to 1 or more tag types
         # Try all regex to build a list of preferred / higher rank tag types 
-        if self.tag_types is None:
+        if self.tag_types is None: 
             self.tag_types = set()
             reference_types = self.lang.get('reference_types', {})
             for re_ref, lstTypes in reference_types.items():
@@ -126,11 +126,11 @@ class RankMgr:
         Tag from same file as reference and this|self.method() --> Double boost rank
         Note: Inheritence model (base class in different file) is not yet supported.
         """ 
-        if self.reThis is None and self.mbr_exp:
+        if self.reThis is None:
             lstThis = self.mbr_exp.get('this')
             if lstThis:
                 self.reThis = re.compile(concat_re(lstThis), re.IGNORECASE)
-            else:
+            elif self.mbr_exp:
                 print('Warning! Language that has syntax settings is expected to define this|self expression syntax')
         
         rank = 0

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -1,0 +1,163 @@
+"""
+Rank and Filter support for ctags plugin for Sublime Text 2/3.
+"""
+
+import functools
+from functools import reduce
+import locale
+import sys
+import os
+import pprint
+import re
+import string
+import threading
+import subprocess
+from itertools import chain
+from operator import itemgetter as iget
+from collections import defaultdict, deque
+
+from helpers.common import *
+
+def compile_definition_filters(view):
+    filters = []
+    for selector, regexes in list(get_setting('definition_filters', {}).items()):
+        if view.match_selector(view.sel() and view.sel()[0].begin() or 0,
+                               selector):
+            filters.append(regexes)
+    return filters
+
+def get_grams(str):
+    lstr = str.lower()
+    return set(zip(lstr,lstr[1:],lstr[2:]))
+
+class RankMgr:
+    """
+    For each matched Tag, calculates the rank score or filter it out. The remaining matches are sorted by decending score. 
+    """
+    def __init__(self,region, mbrParts, view):
+        print('RankMgr init')
+        
+        self.region = region
+        self.mbrParts = mbrParts
+        self.view = view
+
+        self.def_filters = compile_definition_filters(view)
+
+        self.fname_abs = view.file_name().lower() if not(view.file_name() is None) else None        
+        
+         # Return a set of tri-grams (each tri-gram is a tuple) given a string: 
+        # Ex: 'Dekel' --> {('d', 'e', 'k'), ('k', 'e', 'l'), ('e', 'k', 'e')}
+        
+        mbrGrams = [get_grams(part) for part in mbrParts];
+        self.setMbrGrams = (reduce(lambda s,t: s.union(t), mbrGrams) if mbrGrams else set() )
+        print('setMbrGrams = %s' % self.setMbrGrams);
+            
+    # Object Member Expression File Ranking: Rank higher candiates tags path names that fuzzy match the <expression>.method()
+    # Rules:
+    # 1) youtube.fetch() --> mbrPaths = ['youtube'] --> get_rank of tag 'fetch' with rel_path a/b/Youtube.js ---> RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
+    # 2) youtube.fetch() --> user GotoDef from youtube.js --> RANK_EQ_FILENAME_RANK
+    # 3) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
+    RANK_EQ_FILENAME_RANK = 10
+    RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME = 20
+    WEIGHT_RIGHTMOST_MBR_PART = 2
+    MAX_WEIGHT_GRAM = 3
+    WEIGHT_DECAY = 1.5
+    reThis = re.compile('this|self|me|that', re.IGNORECASE) #TODO: this/self config
+    def get_rank(self,rel_path,mbrParts):
+#           print('get_rank.rel_path = %s' % rel_path);
+        
+        rank = 0
+        rel_path_no_ext = rel_path.lstrip('.' + os.sep)
+        rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]
+        pathParts = rel_path_no_ext.split(os.sep);
+        if len(pathParts) >= 1 and len(mbrParts) >= 1 and pathParts[-1].lower() == mbrParts[-1].lower():
+            rank += self.RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
+#                print('Boost: pathParts[-1].lower() == mbrParts[-1].lower() %d' % rank)
+                
+        # Same file --> Boost rank
+        if self.eq_filename(rel_path): 
+            rank += self.RANK_EQ_FILENAME_RANK
+            print('Same file: %d' % rank)
+            if len(mbrParts) == 1 and self.reThis.match(mbrParts[-1]):
+                rank += self.RANK_EQ_FILENAME_RANK # this.mtd() -  rank candidate from current file very high.
+                print('Same file + this: %d' % rank)
+                return rank
+            
+        # Prepare dict of <tri-gram : weight>, where weight decays are we move further away from the method call (to the left)
+        pathGrams = [get_grams(part) for part in pathParts];
+#           print('pathGrams = %s' % pathGrams);
+        wt = self.MAX_WEIGHT_GRAM
+        dctPathGram = {}
+        for setPathGram in reversed(pathGrams):                
+            dctPathPart = dict.fromkeys(setPathGram,wt)
+            dctPathGram = merge_two_dicts_shallow(dctPathPart,dctPathGram)
+            wt /= self.WEIGHT_DECAY
+        
+#            print('dctPathGram = %s' % dctPathGram);
+        
+        for mbrGrm in self.setMbrGrams:
+            rank += dctPathGram.get(mbrGrm,0)
+        
+#           print('rank = %d' % rank);
+        return rank
+
+    def pass_def_filter(self,o):
+            for f in self.def_filters:
+                for k, v in list(f.items()):
+                    if k in o:
+                        if re.match(v, o[k]):
+                            return False
+            return True
+        
+        
+    def eq_filename(self,rel_path):
+        if self.fname_abs is None or rel_path is None:
+            return False    
+        return self.fname_abs.endswith(rel_path.lstrip('.').lower())
+    
+    # Given optional scope extended field tag.scope = 'startline:startcol-endline:endcol' -  def-scope. 
+    # Return: Tuple of 2 Lists: 
+    #  in_scope: Tags with matching scope: current cursor / caret position is contained in their start-end scope range.
+    #  no_scope: Tags without scope or with global scope 
+    # Usage: locals, local parameters Tags have scope (ex: in estr.js tag generator for JavaScript)
+    def scope_filter(self,taglist):
+        in_scope = []
+        no_scope = []
+        for tag in taglist:
+            if self.region is None or tag.get('scope') is None or tag.scope is None or tag.scope == 'global':
+                no_scope.append(tag)
+                continue
+
+            if not self.eq_filename(tag.filename):
+                continue
+        
+            mch = re.search(get_setting('scope_re'),tag.scope) 
+            
+            if mch:
+                beginLine = int(mch.group(1)) - 1 # .tags file is 1 based and region.begin() is 0 based
+                beginCol  = int(mch.group(2)) - 1
+                endLine = int(mch.group(3)) - 1
+                endCol  = int(mch.group(4)) - 1
+                beginPoint = self.view.text_point(beginLine,beginCol)
+                endPoint = self.view.text_point(endLine,endCol)                
+                if self.region.begin() >= beginPoint and self.region.end() <= endPoint:                    
+                    in_scope.append(tag)
+                    
+
+        return (in_scope,no_scope)    
+
+    def sort_tags(self,taglist):
+        # Scope Filter: If symbol matches at least 1 local scope tag - assume they hides non-scope and global scope tags. 
+        # If no local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard 
+        # the local-scope - because they are not locals of the current position                                
+        # If object-receiver (someobj.symbol) --> refer to as global tag --> filter out local-scope tags
+        (in_scope,no_scope) = self.scope_filter(taglist)
+        if (len(self.setMbrGrams) == 0 and len(in_scope) > 0): #TODO:Config: @symbol - in Ruby instance var (therefore never local var)
+            p_tags = in_scope
+        else:                
+            p_tags = no_scope
+
+        p_tags = list(filter(lambda tag: self.pass_def_filter(tag), p_tags))
+        p_tags = sorted(p_tags, key=lambda tag: self.get_rank(tag.tag_path[0],self.mbrParts),reverse=True )   
+        return p_tags
+

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -163,7 +163,7 @@ class RankMgr:
         2) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
         """
         rank = 0
-        if (!mbrParts): return rank
+        if  len(mbrParts) == 0: return rank
         
         rel_path_no_ext = rel_path.lstrip('.' + os.sep)
         rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -2,19 +2,12 @@
 Rank and Filter support for ctags plugin for Sublime Text 2/3.
 """
 
-import functools
 from functools import reduce
-import locale
 import sys
 import os
-import pprint
 import re
 import string
-import threading
-import subprocess
-from itertools import chain
-from operator import itemgetter as iget
-from collections import defaultdict, deque
+
 
 from helpers.common import *
 

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -45,7 +45,6 @@ class RankMgr:
         # Used by Rank by Definition Types
         self.symbol = symbol
         self.sym_line = sym_line 
-        self.tag_types = None
         
         self.lang = get_lang_setting(get_source(view))
         self.mbr_exp = self.lang.get('member_exp')
@@ -56,110 +55,21 @@ class RankMgr:
               
         mbrGrams = [get_grams(part) for part in mbrParts];
         self.setMbrGrams = (reduce(lambda s,t: s.union(t), mbrGrams) if mbrGrams else set() )
-        print('setMbrGrams = %s' % self.setMbrGrams);
-
-    RANK_MATCH_TYPE = 30
-    def get_type_rank(self,tag):
-        """
-        Rank by Definition Types: Rank Higher matching definitions with types matching to the GotoDef <reference>
-        Use regex to identify the <reference> type 
-        """
-        # First time - compare current symbol line to the per-language list of regex: Each regex is mapped to 1 or more tag types
-        # Try all regex to build a list of preferred / higher rank tag types 
-        if self.tag_types is None:
-            self.tag_types = set()
-            reference_types = self.lang.get('reference_types', {})
-            for re_ref, lstTypes in reference_types.items():
-                # replace special keyword __symbol__ with our reference symbol
-                cur_re = re_ref.replace('__symbol__',self.symbol)
-                if (re.search(cur_re,self.sym_line)):
-                    self.tag_types = self.tag_types.union(lstTypes)
-
-        return self.RANK_MATCH_TYPE if tag.type in self.tag_types else 0
-
-
-    RANK_EQ_FILENAME_RANK = 10
-    reThis = None
-    def get_samefile_rank(self,rel_path,mbrParts):
-        """
-        Tag from same file as reference --> Boost rank
-        Tag from same file as reference and this|self.method() --> Double boost rank
-        Note: Inheritence model (base class in different file) is not yet supported.
-        """ 
-        if self.reThis is None and self.mbr_exp:
-            lstThis = self.mbr_exp.get('this')
-            if lstThis:
-                self.reThis = re.compile(concat_re(lstThis), re.IGNORECASE)
-            else:
-                print('Warning! Language that has syntax settings is expected to define this|self expression syntax')
-        
-        rank = 0
-        if self.eq_filename(rel_path): 
-            rank += self.RANK_EQ_FILENAME_RANK
-            print('Same file: %d' % rank)
-            if len(mbrParts) == 1 and self.reThis and self.reThis.match(mbrParts[-1]):
-                rank += self.RANK_EQ_FILENAME_RANK # this.mtd() -  rank candidate from current file very high.
-                print('Same file + this: %d' % rank)
-        return rank
-    
-    
-    # Object Member Expression File Ranking: Rank higher candiates tags path names that fuzzy match the <expression>.method()
-    # Rules:
-    # 1) youtube.fetch() --> mbrPaths = ['youtube'] --> get_rank of tag 'fetch' with rel_path a/b/Youtube.js ---> RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
-    # 2) youtube.fetch() --> user GotoDef from youtube.js --> RANK_EQ_FILENAME_RANK
-    # 3) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
-    
-    RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME = 20
-    
-    WEIGHT_RIGHTMOST_MBR_PART = 2
-    MAX_WEIGHT_GRAM = 3
-    WEIGHT_DECAY = 1.5
-    def get_rank(self,tag,mbrParts):        
-        rank = 0
-
-        # Type definition Rank
-        rank += self.get_type_rank(tag)
-
-        rel_path = tag.tag_path[0]
-        # Same file and this.method() ranking        
-        rank+= self.get_samefile_rank(rel_path,mbrParts)
-        
-        
-        rel_path_no_ext = rel_path.lstrip('.' + os.sep)
-        rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]
-        pathParts = rel_path_no_ext.split(os.sep);
-        if len(pathParts) >= 1 and len(mbrParts) >= 1 and pathParts[-1].lower() == mbrParts[-1].lower():
-            rank += self.RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
-        
-        # Prepare dict of <tri-gram : weight>, where weight decays are we move further away from the method call (to the left)
-        pathGrams = [get_grams(part) for part in pathParts];
-        wt = self.MAX_WEIGHT_GRAM
-        dctPathGram = {}
-        for setPathGram in reversed(pathGrams):                
-            dctPathPart = dict.fromkeys(setPathGram,wt)
-            dctPathGram = merge_two_dicts_shallow(dctPathPart,dctPathGram)
-            wt /= self.WEIGHT_DECAY
-        
-        for mbrGrm in self.setMbrGrams:
-            rank += dctPathGram.get(mbrGrm,0)
-        
-#           print('rank = %d' % rank);
-        return rank
+#        print('setMbrGrams = %s' % self.setMbrGrams);
 
     def pass_def_filter(self,o):
-            for f in self.def_filters:
-                for k, v in list(f.items()):
-                    if k in o:
-                        if re.match(v, o[k]):
-                            return False
-            return True
-        
+        for f in self.def_filters:
+            for k, v in list(f.items()):
+                if k in o:
+                    if re.match(v, o[k]):
+                        return False
+        return True
+    
         
     def eq_filename(self,rel_path):
         if self.fname_abs is None or rel_path is None:
             return False    
         return self.fname_abs.endswith(rel_path.lstrip('.').lower())
-    
     
     def scope_filter(self,taglist):
         """
@@ -194,6 +104,105 @@ class RankMgr:
 
         return (in_scope,no_scope)    
 
+    RANK_MATCH_TYPE = 30
+    tag_types = None
+    def get_type_rank(self,tag):
+        """
+        Rank by Definition Types: Rank Higher matching definitions with types matching to the GotoDef <reference>
+        Use regex to identify the <reference> type 
+        """
+        # First time - compare current symbol line to the per-language list of regex: Each regex is mapped to 1 or more tag types
+        # Try all regex to build a list of preferred / higher rank tag types 
+        if self.tag_types is None:
+            self.tag_types = set()
+            reference_types = self.lang.get('reference_types', {})
+            for re_ref, lstTypes in reference_types.items():
+                # replace special keyword __symbol__ with our reference symbol
+                cur_re = re_ref.replace('__symbol__',self.symbol)
+                if (re.search(cur_re,self.sym_line)):
+                    self.tag_types = self.tag_types.union(lstTypes)
+
+        return self.RANK_MATCH_TYPE if tag.type in self.tag_types else 0
+
+
+    RANK_EQ_FILENAME_RANK = 10
+    reThis = None
+    def get_samefile_rank(self,rel_path,mbrParts):
+        """
+        If both reference and definition (tag) are in the same file --> Rank this tag higher.
+        Tag from same file as reference --> Boost rank
+        Tag from same file as reference and this|self.method() --> Double boost rank
+        Note: Inheritence model (base class in different file) is not yet supported.
+        """ 
+        if self.reThis is None and self.mbr_exp:
+            lstThis = self.mbr_exp.get('this')
+            if lstThis:
+                self.reThis = re.compile(concat_re(lstThis), re.IGNORECASE)
+            else:
+                print('Warning! Language that has syntax settings is expected to define this|self expression syntax')
+        
+        rank = 0
+        if self.eq_filename(rel_path): 
+            rank += self.RANK_EQ_FILENAME_RANK
+            print('Same file: %d' % rank)
+            if len(mbrParts) == 1 and self.reThis and self.reThis.match(mbrParts[-1]):
+                rank += self.RANK_EQ_FILENAME_RANK # this.mtd() -  rank candidate from current file very high.
+                print('Same file + this: %d' % rank)
+        return rank
+    
+    
+    RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME = 20
+    WEIGHT_RIGHTMOST_MBR_PART = 2
+    MAX_WEIGHT_GRAM = 3
+    WEIGHT_DECAY = 1.5
+    def get_mbr_exp_match_tagfile_rank(self,rel_path,mbrParts):
+        """
+        Object Member Expression File Ranking: Rank higher candiates tags path names that fuzzy match the <expression>.method()
+        Rules:
+        1) youtube.fetch() --> mbrPaths = ['youtube'] --> get_rank of tag 'fetch' with rel_path a/b/Youtube.js ---> RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
+        2) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
+        """
+        rank = 0
+        rel_path_no_ext = rel_path.lstrip('.' + os.sep)
+        rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]
+        pathParts = rel_path_no_ext.split(os.sep);
+        if len(pathParts) >= 1 and len(mbrParts) >= 1 and pathParts[-1].lower() == mbrParts[-1].lower():
+            rank += self.RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
+        
+        # Prepare dict of <tri-gram : weight>, where weight decays are we move further away from the method call (to the left)
+        pathGrams = [get_grams(part) for part in pathParts];
+        wt = self.MAX_WEIGHT_GRAM
+        dctPathGram = {}
+        for setPathGram in reversed(pathGrams):                
+            dctPathPart = dict.fromkeys(setPathGram,wt)
+            dctPathGram = merge_two_dicts_shallow(dctPathPart,dctPathGram)
+            wt /= self.WEIGHT_DECAY
+        
+        for mbrGrm in self.setMbrGrams:
+            rank += dctPathGram.get(mbrGrm,0)
+        
+        return rank
+        
+    def get_combined_rank(self,tag,mbrParts):     
+        """
+        Calculate rank score per tag, combining several heuristics
+        """
+        rank = 0
+
+        # Type definition Rank
+        rank += self.get_type_rank(tag)
+
+        rel_path = tag.tag_path[0]
+        # Same file and this.method() ranking        
+        rank+= self.get_samefile_rank(rel_path,mbrParts)
+        
+        # Object Member Expression File Ranking
+        rank+= self.get_mbr_exp_match_tagfile_rank(rel_path,mbrParts)
+        
+#       print('rank = %d' % rank);
+        return rank
+
+    
     def sort_tags(self,taglist):
         # Scope Filter: If symbol matches at least 1 local scope tag - assume they hides non-scope and global scope tags. 
         # If no local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard 
@@ -206,6 +215,6 @@ class RankMgr:
             p_tags = no_scope
 
         p_tags = list(filter(lambda tag: self.pass_def_filter(tag), p_tags))
-        p_tags = sorted(p_tags, key=lambda tag: self.get_rank(tag,self.mbrParts),reverse=True )   
+        p_tags = sorted(p_tags, key=lambda tag: self.get_combined_rank(tag,self.mbrParts),reverse=True )   
         return p_tags
 

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -163,6 +163,8 @@ class RankMgr:
         2) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
         """
         rank = 0
+        if (!mbrParts): return rank
+        
         rel_path_no_ext = rel_path.lstrip('.' + os.sep)
         rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]
         pathParts = rel_path_no_ext.split(os.sep);

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -29,6 +29,10 @@ def compile_definition_filters(view):
     return filters
 
 def get_grams(str):
+    """
+    Return a set of tri-grams (each tri-gram is a tuple) given a string: 
+    Ex: 'Dekel' --> {('d', 'e', 'k'), ('k', 'e', 'l'), ('e', 'k', 'e')}
+    """
     lstr = str.lower()
     return set(zip(lstr,lstr[1:],lstr[2:]))
 
@@ -61,10 +65,7 @@ class RankMgr:
         self.def_filters = compile_definition_filters(view)
 
         self.fname_abs = view.file_name().lower() if not(view.file_name() is None) else None        
-        
-         # Return a set of tri-grams (each tri-gram is a tuple) given a string: 
-        # Ex: 'Dekel' --> {('d', 'e', 'k'), ('k', 'e', 'l'), ('e', 'k', 'e')}
-        
+              
         mbrGrams = [get_grams(part) for part in mbrParts];
         self.setMbrGrams = (reduce(lambda s,t: s.union(t), mbrGrams) if mbrGrams else set() )
         print('setMbrGrams = %s' % self.setMbrGrams);

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -11,143 +11,155 @@ import string
 
 from helpers.common import *
 
+
 def compile_definition_filters(view):
     filters = []
-    for selector, regexes in list(get_setting('definition_filters', {}).items()):
+    for selector, regexes in list(
+            get_setting('definition_filters', {}).items()):
         if view.match_selector(view.sel() and view.sel()[0].begin() or 0,
                                selector):
             filters.append(regexes)
     return filters
 
+
 def get_grams(str):
     """
-    Return a set of tri-grams (each tri-gram is a tuple) given a string: 
+    Return a set of tri-grams (each tri-gram is a tuple) given a string:
     Ex: 'Dekel' --> {('d', 'e', 'k'), ('k', 'e', 'l'), ('e', 'k', 'e')}
     """
     lstr = str.lower()
-    return set(zip(lstr,lstr[1:],lstr[2:]))
+    return set(zip(lstr, lstr[1:], lstr[2:]))
+
 
 class RankMgr:
     """
-    For each matched Tag, calculates the rank score or filter it out. The remaining matches are sorted by decending score. 
+    For each matched Tag, calculates the rank score or filter it out. The remaining matches are sorted by decending score.
     """
-    def __init__(self,region, mbrParts, view,symbol,sym_line):
+
+    def __init__(self, region, mbrParts, view, symbol, sym_line):
         self.region = region
         self.mbrParts = mbrParts
         self.view = view
         # Used by Rank by Definition Types
         self.symbol = symbol
-        self.sym_line = sym_line 
-        
+        self.sym_line = sym_line
+
         self.lang = get_lang_setting(get_source(view))
-        self.mbr_exp = self.lang.get('member_exp',{})
-            
+        self.mbr_exp = self.lang.get('member_exp', {})
+
         self.def_filters = compile_definition_filters(view)
 
-        self.fname_abs = view.file_name().lower() if not(view.file_name() is None) else None        
-              
-        mbrGrams = [get_grams(part) for part in mbrParts];
-        self.setMbrGrams = (reduce(lambda s,t: s.union(t), mbrGrams) if mbrGrams else set() )
+        self.fname_abs = view.file_name().lower() if not(
+            view.file_name() is None) else None
 
-    def pass_def_filter(self,o):
+        mbrGrams = [get_grams(part) for part in mbrParts]
+        self.setMbrGrams = (
+            reduce(
+                lambda s,
+                t: s.union(t),
+                mbrGrams) if mbrGrams else set())
+
+    def pass_def_filter(self, o):
         for f in self.def_filters:
             for k, v in list(f.items()):
                 if k in o:
                     if re.match(v, o[k]):
                         return False
         return True
-    
-        
-    def eq_filename(self,rel_path):
+
+    def eq_filename(self, rel_path):
         if self.fname_abs is None or rel_path is None:
-            return False    
+            return False
         return self.fname_abs.endswith(rel_path.lstrip('.').lower())
-    
-    def scope_filter(self,taglist):
+
+    def scope_filter(self, taglist):
         """
-        Given optional scope extended field tag.scope = 'startline:startcol-endline:endcol' -  def-scope. 
-        Return: Tuple of 2 Lists: 
+        Given optional scope extended field tag.scope = 'startline:startcol-endline:endcol' -  def-scope.
+        Return: Tuple of 2 Lists:
         in_scope: Tags with matching scope: current cursor / caret position is contained in their start-end scope range.
-        no_scope: Tags without scope or with global scope 
+        no_scope: Tags without scope or with global scope
         Usage: locals, local parameters Tags have scope (ex: in estr.js tag generator for JavaScript)
         """
         in_scope = []
         no_scope = []
         for tag in taglist:
-            if self.region is None or tag.get('scope') is None or tag.scope is None or tag.scope == 'global':
+            if self.region is None or tag.get(
+                    'scope') is None or tag.scope is None or tag.scope == 'global':
                 no_scope.append(tag)
                 continue
 
             if not self.eq_filename(tag.filename):
                 continue
-        
-            mch = re.search(get_setting('scope_re'),tag.scope) 
-            
-            if mch:
-                beginLine = int(mch.group(1)) - 1 # .tags file is 1 based and region.begin() is 0 based
-                beginCol  = int(mch.group(2)) - 1
-                endLine = int(mch.group(3)) - 1
-                endCol  = int(mch.group(4)) - 1
-                beginPoint = self.view.text_point(beginLine,beginCol)
-                endPoint = self.view.text_point(endLine,endCol)                
-                if self.region.begin() >= beginPoint and self.region.end() <= endPoint:                    
-                    in_scope.append(tag)
-                    
 
-        return (in_scope,no_scope)    
+            mch = re.search(get_setting('scope_re'), tag.scope)
+
+            if mch:
+                # .tags file is 1 based and region.begin() is 0 based
+                beginLine = int(mch.group(1)) - 1
+                beginCol = int(mch.group(2)) - 1
+                endLine = int(mch.group(3)) - 1
+                endCol = int(mch.group(4)) - 1
+                beginPoint = self.view.text_point(beginLine, beginCol)
+                endPoint = self.view.text_point(endLine, endCol)
+                if self.region.begin() >= beginPoint and self.region.end() <= endPoint:
+                    in_scope.append(tag)
+
+        return (in_scope, no_scope)
 
     RANK_MATCH_TYPE = 30
     tag_types = None
-    def get_type_rank(self,tag):
+
+    def get_type_rank(self, tag):
         """
         Rank by Definition Types: Rank Higher matching definitions with types matching to the GotoDef <reference>
-        Use regex to identify the <reference> type 
+        Use regex to identify the <reference> type
         """
         # First time - compare current symbol line to the per-language list of regex: Each regex is mapped to 1 or more tag types
-        # Try all regex to build a list of preferred / higher rank tag types 
-        if self.tag_types is None: 
+        # Try all regex to build a list of preferred / higher rank tag types
+        if self.tag_types is None:
             self.tag_types = set()
             reference_types = self.lang.get('reference_types', {})
             for re_ref, lstTypes in reference_types.items():
                 # replace special keyword __symbol__ with our reference symbol
-                cur_re = re_ref.replace('__symbol__',self.symbol)
-                if (re.search(cur_re,self.sym_line)):
+                cur_re = re_ref.replace('__symbol__', self.symbol)
+                if (re.search(cur_re, self.sym_line)):
                     self.tag_types = self.tag_types.union(lstTypes)
 
         return self.RANK_MATCH_TYPE if tag.type in self.tag_types else 0
 
-
     RANK_EQ_FILENAME_RANK = 10
     reThis = None
-    def get_samefile_rank(self,rel_path,mbrParts):
+
+    def get_samefile_rank(self, rel_path, mbrParts):
         """
         If both reference and definition (tag) are in the same file --> Rank this tag higher.
         Tag from same file as reference --> Boost rank
         Tag from same file as reference and this|self.method() --> Double boost rank
         Note: Inheritence model (base class in different file) is not yet supported.
-        """ 
+        """
         if self.reThis is None:
             lstThis = self.mbr_exp.get('this')
             if lstThis:
                 self.reThis = re.compile(concat_re(lstThis), re.IGNORECASE)
             elif self.mbr_exp:
-                print('Warning! Language that has syntax settings is expected to define this|self expression syntax')
-        
+                print(
+                    'Warning! Language that has syntax settings is expected to define this|self expression syntax')
+
         rank = 0
-        if self.eq_filename(rel_path): 
+        if self.eq_filename(rel_path):
             rank += self.RANK_EQ_FILENAME_RANK
-            #print('Same file: %d' % rank)
-            if len(mbrParts) == 1 and self.reThis and self.reThis.match(mbrParts[-1]):
-                rank += self.RANK_EQ_FILENAME_RANK # this.mtd() -  rank candidate from current file very high.
-                #print('Same file + this: %d' % rank)
+            if len(mbrParts) == 1 and self.reThis and self.reThis.match(
+                    mbrParts[-1]):
+                # this.mtd() -  rank candidate from current file very high.
+                rank += self.RANK_EQ_FILENAME_RANK
         return rank
-    
-    
+
     RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME = 20
     WEIGHT_RIGHTMOST_MBR_PART = 2
     MAX_WEIGHT_GRAM = 3
     WEIGHT_DECAY = 1.5
-    def get_mbr_exp_match_tagfile_rank(self,rel_path,mbrParts):
+
+    def get_mbr_exp_match_tagfile_rank(self, rel_path, mbrParts):
         """
         Object Member Expression File Ranking: Rank higher candiates tags path names that fuzzy match the <expression>.method()
         Rules:
@@ -155,29 +167,32 @@ class RankMgr:
         2) vidtube.fetch() --> tag 'fetch' with rel_path google/video/youtube.js ---> fuzzy match of tri-grams of vidtube (vid,idt,dtu,tub,ube) with tri-grams from the path
         """
         rank = 0
-        if  len(mbrParts) == 0: return rank
-        
+        if len(mbrParts) == 0:
+            return rank
+
         rel_path_no_ext = rel_path.lstrip('.' + os.sep)
         rel_path_no_ext = os.path.splitext(rel_path_no_ext)[0]
-        pathParts = rel_path_no_ext.split(os.sep);
-        if len(pathParts) >= 1 and len(mbrParts) >= 1 and pathParts[-1].lower() == mbrParts[-1].lower():
+        pathParts = rel_path_no_ext.split(os.sep)
+        if len(pathParts) >= 1 and len(
+                mbrParts) >= 1 and pathParts[-1].lower() == mbrParts[-1].lower():
             rank += self.RANK_EXACT_MATCH_RIGHTMOST_MBR_PART_TO_FILENAME
-        
-        # Prepare dict of <tri-gram : weight>, where weight decays are we move further away from the method call (to the left)
-        pathGrams = [get_grams(part) for part in pathParts];
+
+        # Prepare dict of <tri-gram : weight>, where weight decays are we move
+        # further away from the method call (to the left)
+        pathGrams = [get_grams(part) for part in pathParts]
         wt = self.MAX_WEIGHT_GRAM
         dctPathGram = {}
-        for setPathGram in reversed(pathGrams):                
-            dctPathPart = dict.fromkeys(setPathGram,wt)
-            dctPathGram = merge_two_dicts_shallow(dctPathPart,dctPathGram)
+        for setPathGram in reversed(pathGrams):
+            dctPathPart = dict.fromkeys(setPathGram, wt)
+            dctPathGram = merge_two_dicts_shallow(dctPathPart, dctPathGram)
             wt /= self.WEIGHT_DECAY
-        
+
         for mbrGrm in self.setMbrGrams:
-            rank += dctPathGram.get(mbrGrm,0)
-        
+            rank += dctPathGram.get(mbrGrm, 0)
+
         return rank
-        
-    def get_combined_rank(self,tag,mbrParts):     
+
+    def get_combined_rank(self, tag, mbrParts):
         """
         Calculate rank score per tag, combining several heuristics
         """
@@ -187,28 +202,30 @@ class RankMgr:
         rank += self.get_type_rank(tag)
 
         rel_path = tag.tag_path[0]
-        # Same file and this.method() ranking        
-        rank+= self.get_samefile_rank(rel_path,mbrParts)
-        
+        # Same file and this.method() ranking
+        rank += self.get_samefile_rank(rel_path, mbrParts)
+
         # Object Member Expression File Ranking
-        rank+= self.get_mbr_exp_match_tagfile_rank(rel_path,mbrParts)
-        
+        rank += self.get_mbr_exp_match_tagfile_rank(rel_path, mbrParts)
+
 #       print('rank = %d' % rank);
         return rank
 
-    
-    def sort_tags(self,taglist):
-        # Scope Filter: If symbol matches at least 1 local scope tag - assume they hides non-scope and global scope tags. 
-        # If no local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard 
-        # the local-scope - because they are not locals of the current position                                
-        # If object-receiver (someobj.symbol) --> refer to as global tag --> filter out local-scope tags
-        (in_scope,no_scope) = self.scope_filter(taglist)
-        if (len(self.setMbrGrams) == 0 and len(in_scope) > 0): #TODO:Config: @symbol - in Ruby instance var (therefore never local var)
+    def sort_tags(self, taglist):
+        # Scope Filter: If symbol matches at least 1 local scope tag - assume they hides non-scope and global scope tags.
+        # If no local-scope (in_scope) matches --> keep the global / no scope matches (see in sorted_tags) and discard
+        # the local-scope - because they are not locals of the current position
+        # If object-receiver (someobj.symbol) --> refer to as global tag -->
+        # filter out local-scope tags
+        (in_scope, no_scope) = self.scope_filter(taglist)
+        if (len(self.setMbrGrams) == 0 and len(in_scope) >
+                0):  # TODO:Config: @symbol - in Ruby instance var (therefore never local var)
             p_tags = in_scope
-        else:                
+        else:
             p_tags = no_scope
 
         p_tags = list(filter(lambda tag: self.pass_def_filter(tag), p_tags))
-        p_tags = sorted(p_tags, key=lambda tag: self.get_combined_rank(tag,self.mbrParts),reverse=True )   
+        p_tags = sorted(
+            p_tags, key=lambda tag: self.get_combined_rank(
+                tag, self.mbrParts), reverse=True)
         return p_tags
-

--- a/ranking/rank.py
+++ b/ranking/rank.py
@@ -48,7 +48,6 @@ class RankMgr:
               
         mbrGrams = [get_grams(part) for part in mbrParts];
         self.setMbrGrams = (reduce(lambda s,t: s.union(t), mbrGrams) if mbrGrams else set() )
-#        print('setMbrGrams = %s' % self.setMbrGrams);
 
     def pass_def_filter(self,o):
         for f in self.def_filters:
@@ -137,10 +136,10 @@ class RankMgr:
         rank = 0
         if self.eq_filename(rel_path): 
             rank += self.RANK_EQ_FILENAME_RANK
-            print('Same file: %d' % rank)
+            #print('Same file: %d' % rank)
             if len(mbrParts) == 1 and self.reThis and self.reThis.match(mbrParts[-1]):
                 rank += self.RANK_EQ_FILENAME_RANK # this.mtd() -  rank candidate from current file very high.
-                print('Same file + this: %d' % rank)
+                #print('Same file + this: %d' % rank)
         return rank
     
     

--- a/tests/data/Main.java
+++ b/tests/data/Main.java
@@ -1,6 +1,6 @@
 class Main {
 	public static void main(String[] args) {
-
+		//get_settings
 	}
 
 }

--- a/tests/data/Main.java
+++ b/tests/data/Main.java
@@ -1,0 +1,6 @@
+class Main {
+	public static void main(String[] args) {
+
+	}
+
+}


### PR DESCRIPTION
New Ranking manager that sorts resulting tags in descending order according to combined score:

1) Scope Filter - filters out tags defined outside of scope (optional if tag generator supports it)
2) Same file and "this". ranking

3) Object Member Expression File Ranking
4) Rank by Definition Types: Rank Higher tags definitions with types matching to the GotoDef <reference> type

Some of the ranking / filtering require optional language syntax settings (see JS,Java and python examples in setting file). If not specified - the specific ranking method is skipped (or not optimal).

Tested with very large JavaScript project (using https://github.com/dekelcohen/estr JS tag generator) and with ctags for python, Java and Ruby projects (brief testing for non-JS languages). 

I believe that with this Ranking methods in place, we are making big steps with GotoDefinition ranking quality towards WebStorm 10.1. As an example,  with my large JS project, I often get better than WebStorm results.
