### PR TITLE
Integrate with sublime's jump history list.

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -17,12 +17,12 @@ import subprocess
 from itertools import chain
 from operator import itemgetter as iget
 from collections import defaultdict, deque
-from Default.history_list import get_jump_history_for_view
 
 try:
     import sublime
     import sublime_plugin
     from sublime import status_message, error_message
+    from Default.history_list import get_jump_history_for_view
 
     # hack the system path to prevent the following issue in ST3
     #     ImportError: No module named 'ctags'
@@ -497,7 +497,10 @@ class JumpPrev(sublime_plugin.WindowCommand):
         name = view.file_name()
         if name:
             sel = [s for s in view.sel()][0]
-            get_jump_history_for_view(view).push_selection(view)
+            try:
+                get_jump_history_for_view(view).push_selection(view)
+            except:
+                pass
             cls.buf.append((name, sel))
 
 # CTags commands

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -17,6 +17,7 @@ import subprocess
 from itertools import chain
 from operator import itemgetter as iget
 from collections import defaultdict, deque
+from Default.history_list import get_jump_history_for_view
 
 try:
     import sublime
@@ -496,6 +497,7 @@ class JumpPrev(sublime_plugin.WindowCommand):
         name = view.file_name()
         if name:
             sel = [s for s in view.sel()][0]
+            get_jump_history_for_view(view).push_selection(view)
             cls.buf.append((name, sel))
 
 # CTags commands


### PR DESCRIPTION
This allows one to use sublime's jump_back and jump_forward commands to navigate after calling navigate_to_definition.

Signed-off-by: Chuck Fossen cfossen@gmail.com
