### PR TITLE
Integrate with Sublime Text history

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -69,8 +69,7 @@ def select(view, region):
     sel_set = view.sel()
     sel_set.clear()
     sel_set.add(region)
-    sublime.set_timeout(functools.partial(view.show_at_center, region), 1)
-
+    sublime.set_timeout(functools.partial(view.show_at_center, region), 200)
 
 def in_main(f):
     @functools.wraps(f)
@@ -514,13 +513,14 @@ def show_build_panel(view):
     a given directory or all open directories.
     """
     display = []
-
+    """
     if view.file_name() is not None:
         if not setting('recursive'):
             display.append(['Open File', view.file_name()])
         else:
             display.append([
                 'Open File\'s Directory', os.path.dirname(view.file_name())])
+    """
 
     if len(view.window().folders()) > 0:
         # append option to build for all open folders
@@ -528,6 +528,10 @@ def show_build_panel(view):
             ['All Open Folders', '; '.join(
                 ['\'{0}\''.format(os.path.split(x)[1])
                  for x in view.window().folders()])])
+        for x in view.window().folders():
+            print(x)
+            print(os.path.split(x))
+            print(os.path.split(x)[1])
         # Append options to build for each open folder
         display.extend(
             [[os.path.split(x)[1], x] for x in view.window().folders()])

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -22,6 +22,7 @@ try:
     import sublime
     import sublime_plugin
     from sublime import status_message, error_message
+    from Default.history_list import get_jump_history_for_view
 
     # hack the system path to prevent the following issue in ST3
     #     ImportError: No module named 'ctags'
@@ -496,6 +497,10 @@ class JumpPrev(sublime_plugin.WindowCommand):
         name = view.file_name()
         if name:
             sel = [s for s in view.sel()][0]
+            try:
+                get_jump_history_for_view(view).push_selection(view)
+            except:
+                pass
             cls.buf.append((name, sel))
 
 # CTags commands


### PR DESCRIPTION
Call get_jump_history_for_view(view).push_selection(view) so jump_back works.

Signed-off-by: Chuck Fossen chuckf@cray.com
