### PR TITLE
fallback to goto_definition if ctag can't be found

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -626,6 +626,9 @@ class JumpToDefinition:
                 break
 
         if not tags:
+            # append to allow jump back to work
+            JumpPrev.append(view)
+            view.window().run_command("goto_definition")
             return status_message('Can\'t find "%s"' % symbol)
 
         rankmgr = RankMgr(region, mbrParts, view, symbol, sym_line)


### PR DESCRIPTION
It works, the only downside I see is that the message `Can't find {{symbol}}` still appears, but I don't know how to get rid of it since `run_command` always return `None`.