### PR TITLE
allow changing opts on project settings file (*.sublime-project)

### DIFF
--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -204,6 +204,10 @@ def find_tags_relative_to(path, tag_file):
 
     return None
 
+def read_opts(view):
+    # the first one is useful to change opts only on a specific project
+    # (by adding ctags.opts to a project settings file)
+    return view.settings().get('ctags.opts') or setting('opts')
 
 def get_alternate_tags_paths(view, tags_file):
     """
@@ -537,7 +541,7 @@ def show_build_panel(view):
             command = setting('command')
             recursive = setting('recursive')
             tag_file = setting('tag_file')
-            opts = setting('opts')
+            opts = read_opts(view)
 
             rebuild_tags = RebuildTags(False)
             rebuild_tags.build_ctags(paths, command, tag_file, recursive, opts)
@@ -822,7 +826,7 @@ class RebuildTags(sublime_plugin.TextCommand):
 
         command = setting('command')
         recursive = setting('recursive')
-        opts = setting('opts')
+        opts = read_opts(self.view)
         tag_file = setting('tag_file')
 
         if 'dirs' in args and args['dirs']:


### PR DESCRIPTION
Allow changing `opts` (as `ctags.opts`) on project settings.

Use case: I am adding this as I have a particular project with many files, I want to ignore some of them when generating ctags to speed up things, so I have added the following to the project settings file (ex: myproject.sublime-project):

```
{
  "settings": {
    "ctags.opts": ["--exclude=@.ctags_ignore"]
  }
}
```
then I created the file `.ctags_ignore` containing the folders I want the ctags command to ignore:
```
node_modules
public/packs
```

I can't simply add `opts` to `Sublime Text/Packages/User/CTags.sublime-settings` as I would need to create a `.ctags_ignore` file for each project, which I don't want to.

References:

- https://forum.sublimetext.com/t/st3-possible-to-change-plugin-settings-in-sublime-project/22264/4
- https://newbedev.com/how-to-exclude-multiple-directories-with-exuberant-ctags