### PR TITLE
Fix file encoding exception

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -476,7 +476,7 @@ class TagFile(object):
         """
         Open file.
         """
-        self.file_o = codecs.open(self.path, 'r+b', encoding='ascii')
+        self.file_o = codecs.open(self.path, 'r+b', encoding='utf-8')
         self.mapped = mmap.mmap(self.file_o.fileno(), 0,
                                 access=mmap.ACCESS_READ)
 


### PR DESCRIPTION
This commit opens .tags files with utf-8 encoding to avoid file encoding exceptions such as the following, which was raised while looking up symbols in linux kernel sources.

```
loading symbols from file
Traceback (most recent call last):
  File "<ST>\Lib\python38\sublime_plugin.py", line 1697, in run_
    return self.run(edit, **args)
  File "<ST>\Data\Packages\CTags\plugins\cmds.py", line 587, in command
    result = func(self, self.view, args, tags_file)
  File "<ST>\Data\Packages\CTags\plugins\cmds.py", line 789, in run
    tags = get_tags()
  File "<ST>\Data\Packages\CTags\plugins\cmds.py", line 778, in get_tags
    return tagfile.get_tags_dict(
  File "<ST>\Data\Packages\CTags\plugins\ctags.py", line 567, in get_tags_dict
    filters = kw.get('filters', [])
  File "<ST>\Data\Packages\CTags\plugins\ctags.py", line 86, in parse_tag_lines
    for line in lines:
  File "<ST>\Data\Packages\CTags\plugins\ctags.py", line 518, in search
    while self.mapped.tell() < self.mapped.size():
  File "./python3.8/codecs.py", line 714, in __next__
  File "./python3.8/codecs.py", line 645, in __next__
  File "./python3.8/codecs.py", line 558, in readline
  File "./python3.8/codecs.py", line 504, in read
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 135: ordinal not in range(128)
```

.tags files are stored using utf-8 and thus must be opened with that encoding.