### PR TITLE
Improve sorting .tag files

### DIFF
--- a/ctags.py
+++ b/ctags.py
@@ -353,19 +353,35 @@ def resort_ctags(tag_file):
 
     :returns: None
     """
-    keys = {}
+    meta = []
+    symbols = []
 
     with codecs.open(tag_file, encoding='utf-8', errors='replace') as file_:
         for line in file_:
-            keys.setdefault(line.split('\t')[FILENAME], []).append(line)
+            if line.startswith('!_TAG'):
+                meta.append(line)
+                continue
+
+            # read all valid symbol tags, which contain at least 
+            # symbol name and containing file and build a list of tuples
+            split = line.split('\t')
+            if len(split) > FILENAME:
+                symbols.append((split[FILENAME], split))
+
+    # sort inplace to save some RAM with large .tags files
+    meta.sort()
+    symbols.sort()
 
     with codecs.open(tag_file+'_sorted_by_file', 'w', encoding='utf-8',
                      errors='replace') as file_:
-        for k in sorted(keys):
-            for line in keys[k]:
-                split = line.split('\t')
-                split[FILENAME] = split[FILENAME].lstrip('.\\')
-                file_.write('\t'.join(split))
+        
+        # write sourted metadata
+        file_.writelines(meta)
+
+        # followed by sorted list of symbols
+        for _, split in symbols:
+            split[FILENAME] = split[FILENAME].lstrip('.\\')
+            file_.write('\t'.join(split))
 
 #
 # Models

--- a/ctags.py
+++ b/ctags.py
@@ -341,7 +341,7 @@ def resort_ctags(tag_file):
             If not exists, create an empty array and store in the
                 dictionary with the file name as key
             Save the line to this list
-        Create a new ``[tagfile]_sorted_by_file`` file
+        Create a new ``tagfile`` file
         For each key in the sorted dictionary
             For each line in the list indicated by the key
                 Split the line on tab character
@@ -355,6 +355,7 @@ def resort_ctags(tag_file):
     """
     meta = []
     symbols = []
+    tmp_file = tag_file + '.tmp'
 
     with codecs.open(tag_file, encoding='utf-8', errors='replace') as file_:
         for line in file_:
@@ -372,7 +373,7 @@ def resort_ctags(tag_file):
     meta.sort()
     symbols.sort()
 
-    with codecs.open(tag_file+'_sorted_by_file', 'w', encoding='utf-8',
+    with codecs.open(tmp_file, 'w', encoding='utf-8',
                      errors='replace') as file_:
         
         # write sourted metadata
@@ -382,6 +383,9 @@ def resort_ctags(tag_file):
         for _, split in symbols:
             split[FILENAME] = split[FILENAME].lstrip('.\\')
             file_.write('\t'.join(split))
+
+    os.remove(tag_file)
+    os.rename(tmp_file, tag_file)
 
 #
 # Models

--- a/ctagsplugin.py
+++ b/ctagsplugin.py
@@ -766,7 +766,6 @@ class ShowSymbols(sublime_plugin.TextCommand):
         else:
             key = ','.join(files)
 
-        tags_file = tags_file + '_sorted_by_file'
         base_path = get_common_ancestor_folder(
             view.file_name(), view.window().folders())
 


### PR DESCRIPTION
Fixes #278
Fixes #329

This commit refactors .tags file post-processing.

1. All metadata lines, beginning with `!_TAG`, are sorted and moved to the top of the output file.

2. Invalid lines are silently dropped. A line is valid, at least contains one `\t`.

3. symbols are stored in a list of tuples rather than a dict, to improve iteration and sorting performance during output phase.

   It has the form of:

   [ filename, ( symbol_name, filename, ... ) ]

   Symbols are sorted by filename, followed by symbol_name.

Note: This is an alternative #279, but without printing warnings and with an
      additional optimizations to avoid splitting lines twice.